### PR TITLE
Update health-checks.rst, replace em-dash with hyphen in dmesg command

### DIFF
--- a/docs/mi300x/health-checks.rst
+++ b/docs/mi300x/health-checks.rst
@@ -151,7 +151,7 @@ diagnostic messages (``dmesg``).
 
 .. code-block:: shell
 
-   sudo dmesg –T | grep amdgpu | grep -i error
+   sudo dmesg -T | grep amdgpu | grep -i error
 
 The expected output should return no results (null).
 


### PR DESCRIPTION
This PR address #6, replacing the en-dash with a hyphen in the dmesg example command