### PR TITLE
Fix typo on line 467, install -> install.sh

### DIFF
--- a/docs/mi300x/performance-bench.rst
+++ b/docs/mi300x/performance-bench.rst
@@ -464,7 +464,7 @@ Build rocBLAS from source by running the following commands in your terminal:
 
    git checkout rocm-6.2.0
 
-   ./install --clients-only --library-path /opt/rocm
+   ./install.sh --clients-only --library-path /opt/rocm
 
 .. note::
 


### PR DESCRIPTION
This issue addresses #10, changing https://github.com/ROCm/system-acceptance-docs/blob/8bf78b509f31cdc99181164fb7ad50c771863f05/docs/mi300x/performance-bench.rst?plain=1#L467

```bash
./install --clients-only --library-path /opt/rocm
```

to

```bash
./install.sh --clients-only --library-path /opt/rocm
```