### PR TITLE
Update v1.2.1

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,15 +1,18 @@
 ACS
+AER
 agfhc
 AGFHC
 agg
 ainic
 AITER
 algbw
+AllGather
 Allreduce
 AllReduce
 amd
 amdgpu
 AMI
+ANP
 ARI
 APBDIS
 api
@@ -41,6 +44,7 @@ bfsort
 BiDi
 BiDir
 biosdevname
+BIOSes
 BKC
 BMC
 Bootloader
@@ -99,6 +103,7 @@ dnf
 dpkg
 dracut
 ds
+durations
 dscp
 DSCP
 DUP
@@ -147,6 +152,7 @@ hclib
 HDDs
 HGEMM
 HPC
+hyperthreading
 HPE
 HPL
 HSA
@@ -313,6 +319,7 @@ QoS
 Radeon
 rccl
 RCCL
+reachability
 rdma
 RDMA
 README
@@ -320,6 +327,7 @@ realloc
 Redfish
 redop
 repo
+Resizable
 reproducibility
 reseat
 reseating
@@ -342,6 +350,7 @@ salina
 scp
 sd
 SGEMM
+SGLang
 SIG
 sigtrap
 SMI

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -86,6 +86,7 @@ CX
 CXXFLAGS
 Datacenter
 DCGPU
+DLC
 dcqcn
 DCQCN
 De
@@ -136,8 +137,10 @@ GFLOPs
 gfortran
 gfx
 GFX
+GMI
 GPUP
 GPUs
+GPU's
 GRand
 GST
 gtu
@@ -180,6 +183,7 @@ ipv
 iso
 iters
 json
+JAX
 JSON
 KASLR
 KERNARG
@@ -409,6 +413,8 @@ uuid
 UUID
 uuids
 VBIOS
+vLLM
+VRMs
 warmup
 wget
 WR

--- a/docs/common/bios-settings.md
+++ b/docs/common/bios-settings.md
@@ -10,38 +10,65 @@ Some server manufacturers offer tools that allow the current BIOS configuration 
 
 For systems with AMD EPYC™ processors, refer to the recommended system BIOS settings for the specific GPU model to ensure the system BIOS is set up correctly for maximum performance. These settings should be set as default values in the system BIOS. Analogous settings for other non-AMI System BIOS providers could be set similarly.
 
-### AMD EPYC BIOS Configuration
-
-The following BIOS settings are recommended for optimal performance with AMD Instinct accelerators. Use this table as a reference to configure each BIOS setting for systems with AMD EPYC™ 9004-series processors and AMI System BIOS to maximize system performance.
-
 ```{note}
-The BIOS settings and location given in the following table may vary by hardware and BIOS vendor; consult your system's documentation for details.
+The BIOS settings and location given in the following tables may vary by hardware and BIOS vendor; consult your system's documentation for details.
 ```
 
 ```{note}
 For systems with Intel processors, some settings might not apply or may be unavailable.
 ```
 
+### Required BIOS Settings
+
+BIOS settings in the following table are universally required for the AMD Instinct MI3xx product line for proper operation.
+
+| **BIOS setting location** | **Parameter** | **Value** | **Comments** |
+| --- | --- | --- | --- |
+| Advanced / PCI subsystem settings | Above 4G decoding | Enabled | GPU large BAR support. |
+| AMD CBS / DF common options / memory addressing | NUMA nodes per socket | NPS1 | A value of NPS1 is suggested for the general use case, but some workloads may have performance improvements with values greater than 1. **A value of 0 (NPS0) is not allowed.** |
+| AMD CBS / DF common options / memory addressing | Memory interleaving | Enabled |  |
+| AMD CBS / NBIO common options | PCIe ten bit tag support | Enabled |  |
+| AMD CBS / NBIO common options | PCIE ARI Enumeration | Enabled |  |
+| AMD CBS / NBIO common options | PCIE ARI Support | Enabled |  |
+
+### BIOS Settings for Virtualization
+
+BIOS settings related to virtualization are required when virtualization features are in use. However, if virtualization is not needed, enabling these settings may reduce performance. Please refer to the tables below for the appropriate configuration for your specific application. For system shipments, AMD recommends using the configuration intended for the virtualization use case.
+
+| **BIOS setting location** | **Parameter** | **Value** | **Comments** |
+| --- | --- | --- | --- |
+| Advanced / PCI subsystem settings | SR-IOV support | Enabled | Enable single root I/O virtualization. |
+| Advanced / PCI subsystem settings | Resizable BAR Support | Enabled | Enabling Resizable BAR Support in the BIOS allows the CPU to access the entire GPU memory space, which is essential for efficiently handling multiple virtual functions. As a result, systems using virtualization or multiple GPU-based virtual functions can share resources more effectively, leading to better performance and responsiveness. Option may not be visible on all system BIOSes. |
+| Advanced / CPU Configuration | SVM Mode | Enabled | Secure Virtual Machine feature of AMD processors. For Intel and ARM based CPUs please use the equivalent option. |
+| AMD CBS / NBIO common options | IOMMU | Enabled |  |
+| AMD CBS / NBIO common options | ACS | Enabled |  |
+
+### BIOS Settings Without Virtualization
+
+If virtualization is not required, the following settings may improve performance.
+
+| **BIOS setting location** | **Parameter** | **Value** | **Comments** |
+| --- | --- | --- | --- |
+| Advanced / PCI subsystem settings | SR-IOV support | Disabled | Single root IO virtualization. **If this feature is disabled, then the kernel command-line must contain the `pci=realloc=off` parameter.** |
+| Advanced / PCI subsystem settings | Resizable BAR Support | N/A | If virtualization is not used, please defer to the system manufacturer for suggested setting. |
+| Advanced / CPU Configuration | SVM Mode | N/A | Secure Virtual Machine feature of AMD processors. For Intel and ARM based CPUs please use the equivalent option. If virtualization is not used, please defer to the system manufacturer for suggested setting. |
+| AMD CBS / NBIO common options | IOMMU | See comment | This setting is workload-dependent. In some scenarios, performance may improve when it is disabled. However, for general use, **it is recommended to keep the feature enabled**, as certain applications require it. |
+| AMD CBS / NBIO common options | ACS | Disabled |  |
+
+### BIOS Settings for Optimal Performance
+
+BIOS settings in the following table are the recommended settings for improved performance with the AMD Instinct MI3xx product line. However, these settings may not be optimal for all platforms or workloads.
+
 | **BIOS setting location** | **Parameter** | **Value** | **Comments** |
 | --- | --- | --- | --- |
 | Advanced / Power Management | Power Management | Maximum Performance | Optimizes power delivery for GPU workloads. |
-| Advanced / CPU Configuration | SVM Mode | Enabled | Required for GPU virtualization features. |
-| Advanced / PCI subsystem settings | Above 4G decoding | Enabled | GPU large BAR support. **Required.** |
-| Advanced / PCI subsystem settings | SR-IOV support | Enabled | Enable single root IO virtualization. **This feature is required for virtualization but can be disabled for improved performance if virtualization is not needed. If this feature is disabled, the kernel command line must contain the pci=realloc=off parameter.** |
 | Advanced / PCI subsystem settings | PCIe Generation | Gen 5 enabled | Ensures maximum PCIe bandwidth for GPU performance. |
 | Advanced / PCI subsystem settings | PCIe Bifurcation | As required | Configure based on GPU installation requirements. |
 | AMD CBS / GPU common options | Global C-state control | Enabled | Global C-states – do not disable this menu item. |
 | AMD CBS / GPU common options | CCD/Core/Thread enablement | Accept | May be necessary to enable the SMT control menu. |
-| AMD CBS / GPU common options / performance | SMT control | Disable | Set to Auto if the primary application is not compute-bound. |
-| AMD CBS / DF common options / memory addressing | NUMA nodes per socket | Auto | Auto = NPS1. At this time, the other options for NUMA nodes per socket should not be used. This is subject to change. **A value of 0 (NPS0) is not allowed.** |
-| AMD CBS / DF common options / memory addressing | Memory interleaving | Enabled | Depends on NUMA nodes (NPS) setting. **Required.** |
+| AMD CBS / GPU common options / performance | SMT control | Disable | If the primary application is not compute-bound or if your workload benefits from hyperthreading, then set this to Auto. |
 | AMD CBS / DF common options / link | 4-link xGMI max speed | 32 Gbps | Auto results in the speed being set to the lower of the max speed the motherboard is designed to support and the max speed of the CPU in use. |
-| AMD CBS / NBIO common options | IOMMU | Enabled | Used for GPU passthrough and virtualization. **Required.** |
-| AMD CBS / NBIO common options | PCIe ten bit tag support | Enabled | **Required** |
-| AMD CBS / NBIO common options | ACS | Enabled | This feature is required for virtualization but can be disabled for improved performance if virtualization is not needed. |
 | AMD CBS / NBIO common options | ASPM | Disable |  |
-| AMD CBS / NBIO common options | PCIE ARI Enumeration | Enabled | **Required** |
-| AMD CBS / NBIO common options | PCIE ARI Support | Enabled | **Required** |
 | AMD CBS / NBIO common options / SMU common options | Determinism control | Manual |  |
 | AMD CBS / NBIO common options / SMU common options | Determinism slider | Power |  |
 | AMD CBS / NBIO common options / SMU common options | cTDP control | Manual | Set cTDP to the maximum supported by the installed CPU. |
@@ -52,6 +79,7 @@ For systems with Intel processors, some settings might not apply or may be unava
 | AMD CBS / NBIO common options / SMU common options | xGMI force width control | Force |  |
 | AMD CBS / NBIO common options / SMU common options | xGMI force link width | 2 | 0: Force xGMI link width to x2  1: Force xGMI link width to x8  2: Force xGMI link width to x16 |
 | AMD CBS / NBIO common options / SMU common options | xGMI max speed | 32Gbps | Auto results in the speed being set to the lower of the max speed the motherboard is designed to support and the max speed of the CPU in use. |
+| AMD CBS / NBIO common options / SMU common options | GMI Folding | Disabled | Disabling Global Memory Interconnect Folding ensures that all GMI communication links between GPUs remain active instead of being down-clocked or powered down to save energy. With all lanes enabled, the GPUs retain full interconnect bandwidth, which can improve multi-GPU communication performance, especially for workloads that are sensitive to inter-GPU bandwidth or latency. |
 | AMD CBS / NBIO common options / SMU common options | APBDIS | 1 | Disables Data Fabric (DF) P-states, contributing to a high-performance power profile. |
 | AMD CBS / NBIO common options / SMU common options | DF C-states | Disabled | DF C-states should be disabled to reduce latency unless a power reduction is needed. This is a key C-State setting for performance. |
 | AMD CBS / NBIO common options / SMU common options | Fixed SOC P-state | P0 | Sets the System-on-Chip to its highest performance state (P0), ensuring optimal GPU-CPU interaction. |

--- a/docs/common/health-checks.md
+++ b/docs/common/health-checks.md
@@ -1,6 +1,6 @@
 # Basic system health checks
 
-Before proceeding with more extensive system validation, it's important to ensure all components in the system are operating at peak performance and bandwidth.
+Before proceeding with more extensive system validation, it's important to ensure all components in the system are operating at peak performance and bandwidth by performing basic system health checks of the single node. Multi-node testing is covered in later sections.
 
 A typical Instinct GPU server architecture consists of the following components:
 
@@ -200,3 +200,11 @@ sudo dmesg -T | grep -i 'error\|warn\|fail\|exception'
   - **Action:** Do not proceed. Analyze each message and troubleshoot accordingly.
 
 See the [technical support reference](../reference/rocm-techsupport.md) for information on the `rocm_techsupport.sh` script utility, which collects system logs for support and troubleshooting.
+
+## Automated Health Checks with the Cluster Validation Suite
+
+Checking kernel parameters, system configuration settings, system memory, and driver errors can be automated using the AMD [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/).
+
+Before running any health or configuration tests, ensure that the `cvs/input/config_file/platform/host_config.json` file is correctly configured for your environment.
+
+After [installing the test suite](https://rocm.docs.amd.com/projects/cvs/en/latest/install/cvs-install.html), run the host configuration test script as described in the ROCm documentation page *Run Cluster Validation Suite Tests* under the [Platform Test Script](https://rocm.docs.amd.com/projects/cvs/en/latest/how-to/run-cvs-tests.html#platform-test-script) section.

--- a/docs/common/kernel-parameters.md
+++ b/docs/common/kernel-parameters.md
@@ -29,9 +29,7 @@ The following steps are for Ubuntu-based systems:
 ```{note}
 For RHEL-based systems, use the grubby tool instead of editing GRUB directly:
 
-```bash
-sudo grubby --update-kernel=ALL --args="pci=bfsort pci=realloc=off iommu=pt numa_balancing=disable modprobe.blacklist=amdgpu"
-```
+    sudo grubby --update-kernel=ALL --args="pci=bfsort pci=realloc=off iommu=pt numa_balancing=disable modprobe.blacklist=amdgpu"
 ```
 
 ## Kernel Parameters
@@ -47,15 +45,13 @@ sudo grubby --update-kernel=ALL --args="pci=bfsort pci=realloc=off iommu=pt numa
 | `numa_balancing=disable` | **Optional.** NUMA balancing allows the OS to scan memory and attempt to migrate to a DIMM logically closer to accessing cores. While beneficial in some scenarios, it adds overhead because the OS is only estimating NUMA allocations, which may be useful if the NUMA locality access is not ideal. |
 | `modprobe.blacklist=amdgpu` | **Optional.** For some system configurations, it is necessary to blacklist the amdgpu driver to prevent instances where the DCGPU may not be ready when the driver loads, or if the system BIOS settings are not optimally configured. If this parameter is used, the amdgpu driver must be loaded post-boot for the system to function properly. Alternatively, configuring the AMD DCGPU with recommended system-optimized BIOS settings might make it possible to remove driver blacklisting. However, blacklisting the driver is considered the safest option since the AMD DCGPU may not be ready during system boot if a firmware update is in progress. |
 
-``````{note}
+```{note}
 If `modprobe.blacklist=amdgpu` is used, the amdgpu module must be loaded after booting:
 
-```bash
-sudo modprobe amdgpu
-```
+    sudo modprobe amdgpu
 
 For deployment, adding a sysctl task to load the amdgpu driver immediately after boot is recommended.
-``````
+```
 
 ### Optional Kernel Parameters
 

--- a/docs/common/kernel-parameters.md
+++ b/docs/common/kernel-parameters.md
@@ -8,6 +8,8 @@ Configuring the correct kernel command-line parameters is essential for stable o
 
 ## GRUB Configuration Steps
 
+The following steps are for Ubuntu-based systems:
+
 1. Open `/etc/default/grub` with root privileges.
 2. Locate the line starting with `GRUB_CMDLINE_LINUX`.
 3. Append all required and recommended parameters to this line.
@@ -17,18 +19,20 @@ Configuring the correct kernel command-line parameters is essential for stable o
    sudo update-grub
    ```
 
-5. For RHEL-based systems, use the grubby tool:
-
-   ```bash
-   sudo grubby --update-kernel=ALL --args="pci=realloc=off"
-   ```
-
-6. Reboot the system for changes to take effect.
-7. Verify the active kernel parameters:
+5. Reboot the system for changes to take effect.
+6. Verify the active kernel parameters:
 
    ```bash
    cat /proc/cmdline
    ```
+
+```{note}
+For RHEL-based systems, use the grubby tool instead of editing GRUB directly:
+
+```bash
+sudo grubby --update-kernel=ALL --args="pci=bfsort pci=realloc=off iommu=pt numa_balancing=disable modprobe.blacklist=amdgpu"
+```
+```
 
 ## Kernel Parameters
 
@@ -40,8 +44,8 @@ Configuring the correct kernel command-line parameters is essential for stable o
 | `pci=bfsort` | Forces the kernel to enumerate all devices on a bus in a breadth-first manner before proceeding to the next bus. This ensures predictable device ordering, important for devices with persistent naming schemes such as network interfaces, and results in improved performance. Using this parameter prevents accessing an unintended GPU over the network. |
 | `iommu=pt` | Enables IOMMU pass-through mode, which allows the adapter to bypass DMA translation to memory, thereby improving performance. IOMMU is a system-specific IO mapping useful for DMA mapping and isolation, particularly in virtualization and device assignments to virtual machines. It is recommended to enable IOMMU support. |
 | `intel_iommu=on` | Necessary for systems with Intel host CPUs; not required for systems with AMD CPUs. |
-| `numa_balancing=disable` | NUMA balancing allows the OS to scan memory and attempt to migrate to a DIMM logically closer to accessing cores. While beneficial in some scenarios, it adds overhead because the OS is only estimating NUMA allocations, which may be useful if the NUMA locality access is not ideal. |
-| `modprobe.blacklist=amdgpu` | For some system configurations, it is necessary to blacklist the amdgpu driver to prevent instances where the DCGPU may not be ready when the driver loads, or if the system BIOS settings are not optimally configured. If this parameter is used, the amdgpu driver must be loaded post-boot for the system to function properly. Alternatively, configuring the AMD DCGPU with recommended system-optimized BIOS settings might make it possible to remove driver blacklisting. However, blacklisting the driver is considered the safest option since the AMD DCGPU may not be ready during system boot if a firmware update is in progress. |
+| `numa_balancing=disable` | **Optional.** NUMA balancing allows the OS to scan memory and attempt to migrate to a DIMM logically closer to accessing cores. While beneficial in some scenarios, it adds overhead because the OS is only estimating NUMA allocations, which may be useful if the NUMA locality access is not ideal. |
+| `modprobe.blacklist=amdgpu` | **Optional.** For some system configurations, it is necessary to blacklist the amdgpu driver to prevent instances where the DCGPU may not be ready when the driver loads, or if the system BIOS settings are not optimally configured. If this parameter is used, the amdgpu driver must be loaded post-boot for the system to function properly. Alternatively, configuring the AMD DCGPU with recommended system-optimized BIOS settings might make it possible to remove driver blacklisting. However, blacklisting the driver is considered the safest option since the AMD DCGPU may not be ready during system boot if a firmware update is in progress. |
 
 ``````{note}
 If `modprobe.blacklist=amdgpu` is used, the amdgpu module must be loaded after booting:

--- a/docs/common/rccl-benchmarking.md
+++ b/docs/common/rccl-benchmarking.md
@@ -101,7 +101,7 @@ The RCCL all-reduce test criteria is to exceed an in-place busbw metric of **304
 
 **Example output:**
 
-```
+```text
 # nThread 1 nGpus 8 minBytes 8 maxBytes 8589934592 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0
 #
 rccl-tests: Version Unknown

--- a/docs/common/rccl-benchmarking.md
+++ b/docs/common/rccl-benchmarking.md
@@ -1,0 +1,175 @@
+# RCCL Benchmarking
+
+The ROCm Collective Communications Library ([ROCm/rccl](https://github.com/ROCm/rccl)) is available as open-source software. Though RCCL is designed to be used as a performant backend for downstream applications, particularly AI training and inference workloads, it also has a test suite to benchmark and validate performance.
+
+GPU collectives can measure performance in several ways, and RCCL benchmarks include both "algorithm" bandwidth and "bus" bandwidth metrics. For point-to-point operations, algorithm bandwidth is a reliable indication of hardware utilization, while for large collective operations bus bandwidth is a better measurement of hardware utilization. For more on the bus band metrics, please refer to the [performance documentation](https://github.com/ROCm/rccl-tests/blob/develop/doc/PERFORMANCE.md) in the RCCL tests repository.
+
+RCCL implements operations such as all-reduce, all-gather, reduce, broadcast, reduce-scatter, gather, scatter, all-to-all, and direct GPU-to-GPU send/receive on the current node or another node.
+
+## RCCL Test Details
+
+### Broadcast
+
+Copies data from one "root" GPU to all others, so every GPU ends up with an identical set of information.
+
+**Performance Metric:** Measures how fast the root GPU can distribute its data to all others, with the focus on the effective bandwidth of this one-to-many transfer.
+
+**Bus Bandwidth (busbw):** Calculated as the total data sent divided by the time taken. Since only the root sends data, busbw reflects the root's ability to saturate the network and is a direct measure of the broadcast efficiency.
+
+### AllGather
+
+Takes a unique chunk of data from each GPU and shares the full collection with every GPU, so everyone has the complete dataset.
+
+**Performance Metric:** Assesses the total bandwidth and efficiency of exchanging and assembling all pieces among GPUs, highlighting how well the network handles simultaneous data sharing.
+
+**Bus Bandwidth (busbw):** Adjusted for the number of GPUs, since each GPU both sends and receives data. This metric shows how efficiently the hardware can handle the collective data transfer required for all_gather.
+
+### AllReduce
+
+Combines data from all GPUs using an operation like sum or max, and then gives the final, combined result back to every GPU.
+
+**Performance Metric:** Measures both the speed of combining data and distributing the result, focusing on throughput and latency-crucial for keeping distributed computations coordinated.
+
+**Bus Bandwidth (busbw):** Considers that each GPU's data must be shared and the result returned, effectively doubling the data movement compared to all_gather. This metric reflects the maximum achievable bandwidth for this two-way communication pattern.
+
+In this document, we report the expected bus bandwidth of the all_reduce operators. Additional tests are available in the [RCCL tests directory](https://github.com/ROCm/rccl-tests/tree/develop/test).
+
+Measurements are reported for bus bandwidth and in-place operations, for message sizes of 8 GB. Higher scores are better.
+
+## RCCL Installation
+
+For running multi-node testing, rccl-tests need to be compiled with MPI support. The [GPU-enabled Message Passing Interface Guide](https://rocm.docs.amd.com/en/docs-6.1.2/how-to/gpu-enabled-mpi.html) contains specific instructions for how to install a ROCm-aware MPI installation for RoCE and InfiniBand-based networks.
+
+### UCX and OpenMPI Installation
+
+Follow the instructions in the [GPU-enabled MPI Guide](https://rocm.docs.amd.com/en/docs-6.1.2/how-to/gpu-enabled-mpi.html) to install UCX and OpenMPI with ROCm support.
+
+### RCCL Installation from Source
+
+RCCL can be installed from source using the following commands. Use the appropriate version tag for your ROCm version:
+
+| ROCm Version | RCCL Tag |
+|--------------|----------|
+| ROCm 7.0.2 | `tags/rocm-7.0.2` |
+| ROCm 7.0.1 | `tags/rocm-7.0.1` |
+| ROCm 6.3.x/6.4.x | `drop/2025-06-J13A-1` |
+
+```bash
+git clone https://github.com/ROCm/rccl.git
+cd rccl
+git checkout <appropriate_tag>
+./install.sh -i
+```
+
+### RCCL-Tests Installation
+
+Once OpenMPI is installed, install RCCL-tests with the following script:
+
+```bash
+# Define preferred paths for MPI and RCCL installations
+# (ensure /lib/libmpi.so and /lib/librccl.so exist in both install paths)
+MPI_INSTALL_DIR=/path/to/mpi
+RCCL_INSTALL_DIR=/path/to/rccl
+
+# If HIP is not installed in /opt/rocm, add `HIP_HOME=/path/to/hip` to the cmake parameters.
+
+build_rccl_tests() {
+  if [ ! -d rccl-tests ]; then
+    git clone https://github.com/ROCm/rccl-tests
+    cd rccl-tests
+    make MPI=1 MPI_HOME=${MPI_INSTALL_DIR} NCCL_HOME=${RCCL_INSTALL_DIR} -j
+  fi
+}
+
+# Build RCCL tests
+build_rccl_tests
+```
+
+This script differs from the previous commands by specifying flags and locations for the MPI install in the cmake parameters. RCCL-tests should now have MPI support.
+
+## Single-Node RCCL Testing
+
+### Allreduce Test
+
+To evaluate the Allreduce operator using the RCCL tests benchmark, run the following command:
+
+```bash
+./all_reduce_perf -b 8 -e 8G -f 2 -g 8
+```
+
+The RCCL all-reduce test criteria is to exceed an in-place busbw metric of **304 GB/s** for MI300X or **350 GB/s** for MI350X/MI355X at a message size of 8 GB.
+
+**Example output:**
+
+```
+# nThread 1 nGpus 8 minBytes 8 maxBytes 8589934592 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0
+#
+rccl-tests: Version Unknown
+# Using devices
+#  Rank  0 Group  0 Pid 657053 on smci350-zts-gtu-e14-05 device  0 [0000:75:00] AMD Instinct MI350X
+#  Rank  1 Group  0 Pid 657053 on smci350-zts-gtu-e14-05 device  1 [0000:05:00] AMD Instinct MI350X
+...
+#                                                              out-of-place                       in-place
+#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong
+#        (B)    (elements)                               (us)  (GB/s)  (GB/s)           (us)  (GB/s)  (GB/s)
+           8             2     float     sum      -1    58.63    0.00    0.00       0    49.68    0.00    0.00       0
+...
+  8589934592    2147483648     float     sum      -1   41644  206.27  360.97       0   40903  210.01  367.51       0
+# Errors with asterisks indicate errors that have exceeded the maximum threshold.
+# Out of bounds values : 0 OK
+# Avg bus bandwidth    : 111.827
+```
+
+The MPI enabled version then runs with one GPU per MPI rank and is launched by mpirun:
+
+```bash
+mpirun -np 8 ./all_reduce_perf -b 8 -e 8G -f 2 -g 1
+```
+
+**Result:**
+
+* **PASSED:** In-place busbw at 8 GB message size is 304 GB/s or greater for MI300X, or 350 GB/s or greater for MI350X/MI355X.
+* **FAILED:** busbw less than expected values.
+
+### Single-Node RCCL Test Script
+
+The following is an example single-node test script that runs all RCCL collectives:
+
+```bash
+#!/usr/bin/bash
+
+# Updated Date: 6/2/2025
+# Notes: Single-node RCCL test script
+
+RCCL_TESTS_DIR=<path_to_rccl_tests>
+TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+
+# Ensure IOMMU is disabled or in passthrough mode
+# Ensure ACS is disabled for consistent results
+
+for bench in all_gather_perf all_reduce_perf alltoall_perf broadcast_perf \
+             gather_perf reduce_perf reduce_scatter_perf scatter_perf sendrecv_perf; do
+  echo "Running ${bench}..."
+  ${RCCL_TESTS_DIR}/build/${bench} -b 8 -e 8G -f 2 -g 8 2>&1 | tee ${TIMESTAMP}_${bench}.txt
+  sleep 5
+done
+```
+
+## Single-Node RCCL with the Cluster Validation Suite
+
+The single-node RCCL tests recommended for deployment can be automated using the [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/).
+
+Before running CVS, ensure that the configuration files for your specific platform and the nodes under test are correctly defined in the `cvs/input/config_file/` subdirectories.
+
+After [installing the test suite](https://rocm.docs.amd.com/projects/cvs/en/latest/install/cvs-install.html), run the single-node RCCL test using:
+
+```bash
+pytest -vvv --log-file=/tmp/test.log -s ./tests/rccl/rccl_singlenode_cvs.py \
+  --cluster_file input/cluster_file/cluster.json \
+  --config_file input/config_file/rccl/single_node_mi355_rccl.json \
+  --html=/var/www/html/cvs/rccl.html --capture=tee-sys --self-contained-html
+```
+
+## Multi-Node RCCL Testing
+
+For multi-node RCCL testing instructions, see the [Network and Cluster Validation](../network/validation.md#rccl-multi-node-fabric-test) section.

--- a/docs/common/system-validation.md
+++ b/docs/common/system-validation.md
@@ -1083,4 +1083,30 @@ AGFHC ends with a return code:
 - 0: All tests passed
 - Non-zero: One or more tests failed
 
-This is useful if integrating AGFHC into scripts or CI pipelines
+This is useful if integrating AGFHC into scripts or CI pipelines.
+
+### Running AGFHC with the Cluster Validation Suite
+
+AGFHC tests recommended for deployment can be automated using the [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/).
+
+Before running CVS, ensure that the configuration files for your specific platform and the nodes under test are correctly defined in the `cvs/input/config_file/` subdirectories.
+
+After [installing the test suite](https://rocm.docs.amd.com/projects/cvs/en/latest/install/cvs-install.html), deploy AGFHC to the cluster using the following command:
+
+```bash
+pytest -vvv --log-file=/tmp/test.log -s ./tests/health/install/install_agfhc.py \
+  --cluster_file input/cluster_file/cluster.json \
+  --config_file input/config_file/health/mi300_health_config.json \
+  --html=/var/www/html/cvs/agfhc.html --capture=tee-sys --self-contained-html
+```
+
+Once AGFHC is installed, run the deployment test set using:
+
+```bash
+pytest -vvv --log-file=/tmp/test.log -s ./tests/health/csp_qual_agfhc.py \
+  --cluster_file input/cluster_file/cluster.json \
+  --config_file input/config_file/health/mi300_health_config.json \
+  --html=/var/www/html/cvs/agfhc.html --capture=tee-sys --self-contained-html
+```
+
+Note that exact tests and durations in the `tests/health/csp_qual_agfhc.py` may differ from this document. Best practice is to run the longer of the two since extended test coverage will reduce the chance of failure after deployment

--- a/docs/common/system-validation.md
+++ b/docs/common/system-validation.md
@@ -797,7 +797,7 @@ AGFHC offers various test levels to suit different validation needs. Individual 
 - To view the available test and recipes:
 
   ```bash
-  /opt/amd/agfhc/agfhc –list
+  /opt/amd/agfhc/agfhc --list
   ```
 
 - To view extended information about a test:
@@ -818,25 +818,43 @@ The tables below list the recommended and suggested AGFHC validation recipes alo
 
 #### Minimum Required AGFHC Tests
 
-| Recipe Name | Applicable Products | Iterations/Duration | Estimated Test Duration |
+| Recipe Name | Applicable Products | Iterations/Duration | Estimated Test Duration / Rationale |
 | --- | --- | --- | --- |
 | all_lvl5 | All AMD MI3xx Instinct™ models | 1 iteration | 2 Hours |
-| hbm_lvl5 | All AMD MI3xx Instinct™ models | 4 iterations | 8 Hours (4 x 2 hours) |
-| minihpl | All AMD MI3xx Instinct™ models | 4 hours | 4 Hours |
-| xgmi_lvl1 | All AMD MI3xx Instinct™ models | 1 iteration | 5 Minutes |
-| pcie_lvl2 | All AMD MI3xx Instinct™ models | 1 iteration | 10 Minutes |
-| Total | | | 14 Hours and 15 Minutes |
+| hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, first iteration | Stress HBM |
+| sleep 300 sec. | | 5 Minutes, second iteration | For silicon to contract to widen any cracks |
+| hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, second iteration | Stress HBM |
+| sleep 300 sec. | | 5 Minutes, third iteration | For silicon to contract to widen any cracks |
+| hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, third iteration | Stress HBM |
+| sleep 300 sec. | | 5 Minutes, fourth iteration | For silicon to contract to widen any cracks |
+| hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, fourth iteration | Stress HBM |
+| sleep 300 sec. | | 5 Minutes, fifth iteration | For silicon to contract to widen any cracks |
+| gfx_lvl4 | All AMD MI3xx Instinct™ models | 1 Hour | GPU stress test to hot spot test GPU needed for DLC systems |
+| sleep 300 sec. | | 5 Minutes, sixth iteration | For silicon to contract to widen any cracks |
+| minihpl | All AMD MI3xx Instinct™ models | 3 Hours | Search for voltage failures and stress HBM |
+| xgmi_lvl1 | All AMD MI3xx Instinct™ models | 5 Minutes | Check for link degradation |
+| pcie_lvl2 | All AMD MI3xx Instinct™ models | 10 Minutes | Check for link degradation |
+| Total | | | 14 Hours and 45 Minutes |
 
 #### Recommended AGFHC Tests
 
-| Recipe Name | Applicable Products | Iterations/Duration | Estimated Test Duration |
+| Recipe Name | Applicable Products | Iterations/Duration | Estimated Test Duration / Rationale |
 | --- | --- | --- | --- |
 | all_lvl5 | All AMD MI3xx Instinct™ models | 1 iteration | 2 Hours |
-| hbm_lvl5 | All AMD MI3xx Instinct™ models | 4 iterations | 8 Hours (4 x 2 hours) |
+| hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, first iteration | Stress HBM |
+| sleep 300 sec. | | 5 Minutes, second iteration | For silicon to contract to widen any cracks |
+| hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, second iteration | Stress HBM |
+| sleep 300 sec. | | 5 Minutes, third iteration | For silicon to contract to widen any cracks |
+| hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, third iteration | Stress HBM |
+| sleep 300 sec. | | 5 Minutes, fourth iteration | For silicon to contract to widen any cracks |
+| hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, fourth iteration | Stress HBM |
+| sleep 300 sec. | | 5 Minutes, fifth iteration | For silicon to contract to widen any cracks |
+| gfx_lvl4 | All AMD MI3xx Instinct™ models | 1 Hour | GPU stress test to hot spot test GPU needed for DLC systems |
+| sleep 300 sec. | | 5 Minutes, sixth iteration | For silicon to contract to widen any cracks |
 | minihpl | All AMD MI3xx Instinct™ models | 10 hours | 10 Hours |
-| xgmi_lvl1 | All AMD MI3xx Instinct™ models | 1 iteration | 5 Minutes |
-| pcie_lvl2 | All AMD MI3xx Instinct™ models | 1 iteration | 10 Minutes |
-| Total | | | 20 Hours and 15 Minutes |
+| xgmi_lvl1 | All AMD MI3xx Instinct™ models | 5 Minutes | Check for link degradation |
+| pcie_lvl2 | All AMD MI3xx Instinct™ models | 10 Minutes | Check for link degradation |
+| Total | | | 20 Hours and 45 Minutes |
 
 ### AGFHC Recipe Coverage Details
 
@@ -941,6 +959,49 @@ Log directory: /root/agfhc/logs/agfhc_20250707-082635
 Program exiting with return code AGFHC_SUCCESS [0]
 ```
 
+#### gfx_lvl4
+
+```{note}
+This test should be run for at least one hour to ensure no issues with the cooling system. Thermal testing the HBM is covered with the HBM tests.
+```
+
+- **GPU thermal stress test:** Executes a GFX matrix workload that combines precision-specific math (FP8/FP16/BF16/FP32/FP64) and transcendental functions. Doing so generates hot spots on the GPU to test the thermal solution.
+- **HBM thermal stress test:** Raw HBM bandwidth with dual concurrent streams (read/write or bidirectional), typically using non-temporal access patterns to bypass caches and hit memory controllers directly.
+- **GPU max power test:** Maximum board power by combining high-utilization compute and memory traffic to exercise SMU power management, VRMs, and thermal solution.
+- **Holistic workloads:** Executing workloads intended to stress both the GPU matrix and the HBM functioning as a graphics sanity check.
+
+Extended information
+
+```bash
+$ /opt/amd/agfhc/agfhc --recipe-info gfx_lvl4
+
+Log Directory: /home/user/agfhc/logs/agfhc_20260325-151748
+Name: gfx_lvl4
+Title: A ~1h GFX workload
+Path: /opt/amd/agfhc/recipes/mi300x/gfx_lvl4.yml
+Contents:
+Test Title Mode Approximate Time
+gfx_dgemm GFX dgemm 1 iteration 0:01:30
+gfx_sgemm GFX sgemm 1 iteration 0:01:15
+gfx_fp8ri GFX fp8 rand int 1 iteration 0:01:20
+gfx_fp16ri GFX fp16 rand int 1 iteration 0:01:20
+gfx_bf16ri GFX bf16 rand int 1 iteration 0:01:20
+gfx_fp8tf GFX fp8 trig float 1 iteration 0:01:20
+gfx_fp16tf GFX fp16 trig float 1 iteration 0:01:20
+gfx_bf16tf GFX bf16 trig float 1 iteration 0:01:20
+hbm_ds_ntd HBM Dual Stream NTD 1 iteration 0:01:10
+gfx_maxpower GFX Max Power 1 iteration 0:10:05
+rochpl rocHPL 2 iterations 0:15:40
+sprites SPRITES 1 iteration 0:20:29
+---------
+Total: 00:58:09
+Summary:
+Tests: 0 Total, 0 Executed, 0 Skipped
+Total Time: 00:00:05
+Log directory: /home/user/agfhc/logs/agfhc_20260325-151748
+Program exiting with return code AGFHC_SUCCESS [0]
+```
+
 #### xgmi_lvl1
 
 - **XGMI Link Health:** Confirms all links are negotiated at expected width and speed.
@@ -1042,8 +1103,17 @@ mkdir /tmp/agfhc_output
 | **Test Name** | **Command Line** |
 | --- | --- |
 | all_lvl5 | /opt/amd/agfhc/agfhc -r all_lvl5 -o /tmp/agfhc_output |
-| hbm_lvl5 | /opt/amd/agfhc/agfhc -r hbm_lvl5:i=4 -o /tmp/agfhc_output |
-| miniHPL | /opt/amd/agfhc/agfhc -t minihpl:d=4h -o /tmp/agfhc_output |
+| hbm_lvl5 | /opt/amd/agfhc/agfhc -r hbm_lvl5 -o /tmp/agfhc_output |
+| sleep | sleep 300 |
+| hbm_lvl5 | /opt/amd/agfhc/agfhc -r hbm_lvl5 -o /tmp/agfhc_output |
+| sleep | sleep 300 |
+| hbm_lvl5 | /opt/amd/agfhc/agfhc -r hbm_lvl5 -o /tmp/agfhc_output |
+| sleep | sleep 300 |
+| hbm_lvl5 | /opt/amd/agfhc/agfhc -r hbm_lvl5 -o /tmp/agfhc_output |
+| sleep | sleep 300 |
+| gfx_lvl4 | /opt/amd/agfhc/agfhc -r gfx_lvl4 -o /tmp/agfhc_output |
+| sleep | sleep 300 |
+| miniHPL | /opt/amd/agfhc/agfhc -t minihpl:d=3h -o /tmp/agfhc_output |
 | xgmi_lvl1 | /opt/amd/agfhc/agfhc -r xgmi_lvl1 -o /tmp/agfhc_output |
 | pcie_lvl2 | /opt/amd/agfhc/agfhc -r pcie_lvl2 -o /tmp/agfhc_output |
 

--- a/docs/common/system-validation.md
+++ b/docs/common/system-validation.md
@@ -820,7 +820,7 @@ The tables below list the recommended and suggested AGFHC validation recipes alo
 
 | Recipe Name | Applicable Products | Iterations/Duration | Estimated Test Duration / Rationale |
 | --- | --- | --- | --- |
-| all_lvl5 | All AMD MI3xx Instinct™ models | 1 iteration | 2 Hours |
+| all_lvl5 | All AMD MI3xx Instinct™ models | 2 hours | Catches most errors |
 | hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, first iteration | Stress HBM |
 | sleep 300 sec. | | 5 Minutes, second iteration | For silicon to contract to widen any cracks |
 | hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, second iteration | Stress HBM |
@@ -840,7 +840,7 @@ The tables below list the recommended and suggested AGFHC validation recipes alo
 
 | Recipe Name | Applicable Products | Iterations/Duration | Estimated Test Duration / Rationale |
 | --- | --- | --- | --- |
-| all_lvl5 | All AMD MI3xx Instinct™ models | 1 iteration | 2 Hours |
+| all_lvl5 | All AMD MI3xx Instinct™ models | 2 hours | Catches most errors |
 | hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, first iteration | Stress HBM |
 | sleep 300 sec. | | 5 Minutes, second iteration | For silicon to contract to widen any cracks |
 | hbm_lvl5 | All AMD MI3xx Instinct™ models | 2 Hours, second iteration | Stress HBM |
@@ -1103,6 +1103,7 @@ mkdir /tmp/agfhc_output
 | **Test Name** | **Command Line** |
 | --- | --- |
 | all_lvl5 | /opt/amd/agfhc/agfhc -r all_lvl5 -o /tmp/agfhc_output |
+| sleep | sleep 300 |
 | hbm_lvl5 | /opt/amd/agfhc/agfhc -r hbm_lvl5 -o /tmp/agfhc_output |
 | sleep | sleep 300 |
 | hbm_lvl5 | /opt/amd/agfhc/agfhc -r hbm_lvl5 -o /tmp/agfhc_output |

--- a/docs/common/workload-validation.md
+++ b/docs/common/workload-validation.md
@@ -1,0 +1,33 @@
+# Workload Validation
+
+Systems under test should be capable of running large AI models, including Large Language Models (LLMs). This section provides guidance on validating AI model performance on AMD Instinct systems.
+
+## AI Model Performance Check
+
+For LLM Inference and Training performance results for validation, refer to the latest [Performance Results with AMD ROCm Software](https://www.amd.com/en/developer/resources/rocm-hub/dev-ai/performance-results.html) on the [AMD ROCm AI Developer Hub](https://www.amd.com/en/developer/resources/rocm-hub/dev-ai.htm) or the [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html).
+
+Detailed instructions on how to reproduce these results can be found at the following links:
+
+* [Measuring inference performance with vLLM](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference/vllm-benchmark.html)
+* [Measuring training performance with ROCm PyTorch Docker](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/pytorch-training.html)
+* [Measuring training performance with ROCm Megatron-LM Docker](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/megatron-lm.html)
+
+## Single-Node Workload Validation
+
+For single-node deployment validation, AMD recommends running Llama 3.1 70B with JAX using the Cluster Validation Suite.
+
+### AI Model Performance Validation with the Cluster Validation Suite
+
+For system validation during deployment, AMD recommends using Llama 3.1 70B with JAX for single-node testing.
+
+The [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/) includes scripts for automatically installing and running these workloads. See the [Jax training test scripts](https://rocm.docs.amd.com/projects/cvs/en/latest/how-to/run-cvs-tests.html#jax-training-test-scripts) section.
+
+The [Megatron](https://rocm.docs.amd.com/projects/cvs/en/latest/how-to/run-cvs-tests.html#megatron-training-test-scripts) workload is also supported as an optional deployment workload.
+
+## Multi-Node Workload Validation
+
+For multi-node workload validation, see the [Network and Cluster Validation](../network/validation.md#ai-workload-validation-with-the-cluster-validation-suite) section.
+
+AMD recommends using the workload of Llama 3.1 405B with JAX for multi-node testing. The runtime will vary depending on the number of nodes, NICs per node, and overall cluster configuration.
+
+There is no multi-node inference benchmark suggested to evaluate clusters at this time, but use of vLLM and SGLang should be considered.

--- a/docs/gpus/mi350x.md
+++ b/docs/gpus/mi350x.md
@@ -90,7 +90,7 @@ These checks ensure fundamental system health and proper GPU detection. For deta
 |------|---------|-------------------|
 | [Check OS distribution](../common/health-checks.md#check-os-distribution) |```cat /etc/os-release``` | **Pass**: OS version listed in compatibility matrix<br>**Fail**: Otherwise |
 | [Check kernel boot arguments](../common/health-checks.md#check-kernel-boot-arguments) | `cat /proc/cmdline` | **Pass**: Shows all required params (`pci=realloc=off pci=bfsort iommu=pt numa_balancing=disable modprobe.blacklist=amdgpu`) + `intel_iommu=on` if Intel<br>**Fail**: Missing any required param |
-| [Check for driver errors](../common/health-checks.md#check-for-driver-errors) | `dmesg | grep -i error` | **Pass**: Null (no GPU-related errors)<br>**Fail**: Errors present |
+| [Check for driver errors](../common/health-checks.md#check-for-driver-errors) | `dmesg \| grep -i error` | **Pass**: Null (no GPU-related errors)<br>**Fail**: Errors present |
 | [Check available memory](../common/health-checks.md#check-for-available-system-memory) | `free -h` / `cat /proc/meminfo` | **Pass**: ≥ 3.0T system memory available<br>**Fail**: < 3.0T |
 | [Check GPU presence](../common/health-checks.md#check-gpu-presence) | `sudo lspci -d 1002:75a0` | **Pass**: 8 MI350X GPUs found<br>**Fail**: Otherwise |
 | [Check GPU link speed and width](../common/health-checks.md#check-gpu-pcie-bus-link-speed-and-width) | `sudo lspci -d 1002:75a0 -vvv \| grep -e DevSta -e LnkSta` | **Pass**: Each GPU: Speed 32GT/s, Width x16, no `FatalErr+`<br>**Fail**: Otherwise |

--- a/docs/gpus/mi355x.md
+++ b/docs/gpus/mi355x.md
@@ -90,10 +90,10 @@ These checks ensure fundamental system health and proper GPU detection. For deta
 |------|---------|-------------------|
 | [Check OS distribution](../common/health-checks.md#check-os-distribution) |```cat /etc/os-release``` | **Pass**: OS version listed in compatibility matrix<br>**Fail**: Otherwise |
 | [Check kernel boot arguments](../common/health-checks.md#check-kernel-boot-arguments) | `cat /proc/cmdline` | **Pass**: Shows all required params (`pci=realloc=off pci=bfsort iommu=pt numa_balancing=disable modprobe.blacklist=amdgpu`) + `intel_iommu=on` if Intel<br>**Fail**: Missing any required param |
-| [Check for driver errors](../common/health-checks.md#check-for-driver-errors) | `dmesg | grep -i error` | **Pass**: Null (no GPU-related errors)<br>**Fail**: Errors present |
+| [Check for driver errors](../common/health-checks.md#check-for-driver-errors) | `dmesg \| grep -i error` | **Pass**: Null (no GPU-related errors)<br>**Fail**: Errors present |
 | [Check available memory](../common/health-checks.md#check-for-available-system-memory) | `free -h` / `cat /proc/meminfo` | **Pass**: ≥ 3.0T system memory available<br>**Fail**: < 3.0T |
 | [Check GPU presence](../common/health-checks.md#check-gpu-presence) | `sudo lspci -d 1002:75a3` | **Pass**: 8 MI355X GPUs found<br>**Fail**: Otherwise |
-| [Check GPU link speed and width](../common/health-checks.md#check-gpu-pcie-bus-link-speed-and-width) | `sudo lspci -d 1002:75a3 -vvv | grep -e DevSta -e LnkSta` | **Pass**: Each GPU: Speed 32GT/s, Width x16, no `FatalErr+`<br>**Fail**: Otherwise |
+| [Check GPU link speed and width](../common/health-checks.md#check-gpu-pcie-bus-link-speed-and-width) | `sudo lspci -d 1002:75a3 -vvv \| grep -e DevSta -e LnkSta` | **Pass**: Each GPU: Speed 32GT/s, Width x16, no `FatalErr+`<br>**Fail**: Otherwise |
 | [Monitor utilization metrics](../common/health-checks.md#monitor-utilization-metrics) | `amd-smi monitor -putm` | **Pass**: Idle metrics as specified<br>**Fail**: Otherwise |
 | [Check system kernel logs for errors](../common/health-checks.md#check-system-kernel-logs) | `sudo dmesg -T \| grep -i 'error\|warn\|fail\|exception'` | **Pass**: Null<br>**Fail**: Otherwise |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,47 @@ This guide follows a two-phase validation approach:
 **Node (GPU/Server) Validation**  
 Establish a known-good baseline for each individual server, including prerequisites verification, firmware and BIOS alignment, kernel parameter configuration, ROCm installation, health checks, GPU validation, microbenchmark performance testing, and acceptance threshold validation per GPU.
 
-**Cluster & Fabric Validation**  
+**Cluster & Fabric Validation**
 Extend validation across multiple nodes, covering NIC driver installation, network routing and configuration, performance optimization, topology mapping, RDMA benchmarking, and comprehensive cluster-level validation.
+
+For more information on AMD Instinct products, applications, configuration, and related software, see the [AMD Instinct Documentation](https://instinct.docs.amd.com/latest/).
+
+## Testing Overview
+
+Testing is generally divided into two categories: single-node tests, which verify the functionality of individual nodes, and multi-node tests, which validate the overall operation of the cluster. An exception to this division is the use of Open Fabrics Enterprise Distribution (OFED) Performance Tests, which are particularly useful for diagnosing network-related issues for a single node such as faulty cables.
+
+The following tables provide estimated test durations; however, these estimates do not include the time required for test configuration or workload file transfers, which can be significant. Actual test durations may vary depending on the number of nodes and the level of thoroughness desired.
+
+### Single Node Tests
+
+| Test | Estimated Duration |
+| --- | --- |
+| CVS Configuration Checker | 12 Minutes |
+| AGFHC all_lvl5 | 2 Hours |
+| AGFHC hbm_lvl5 | 4 Iterations, 8 Hours |
+| AGFHC minihpl | 4 Hours |
+| AGFHC xgmi_lvl1 | 5 Minutes |
+| AGFHC pcie_lvl2 | 10 Minutes |
+| Single Node RCCL | 2 to 11 Minutes |
+| Optional TransferBench | 2 Hours |
+| Optional Llama 3.1 70B | 1 to 24 Hours |
+
+### Multi-Node Tests
+
+| Test | Estimated Duration |
+| --- | --- |
+| OFED Performance Tests | 2 Hours |
+| Multi-node RCCL | 10 Minutes |
+| Llama 3.1 405B with JAX | 1 Hour |
+
+### Cluster Validation Suite
+
+Many of the tasks described in this guide, from checking system configuration to executing single-node and multi-node tests, can be automated using the Cluster Validation Suite (CVS). This toolset verifies the health and performance of AMD AI clusters at scale, extending validation across multiple nodes without requiring extensive manual intervention.
+
+- [Cluster Validation Suite Documentation](https://rocm.docs.amd.com/projects/cvs/en/latest/)
+- [CVS GitHub Repository](https://github.com/ROCm/cvs)
+
+Individual test examples utilizing the CVS for single and multi-node tests are called out in the following sections. Ensure that the configuration files for your specific platform and the nodes under test are correctly defined in the `cvs/input/config_file/` subdirectories before running CVS. Misconfigured files can lead to delays in testing and inaccurate results.
 
 ## Getting Started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,8 @@ The following tables provide estimated test durations; however, these estimates 
 | CVS Configuration Checker | 12 Minutes |
 | AGFHC all_lvl5 | 2 Hours |
 | AGFHC hbm_lvl5 | 4 Iterations, 8 Hours |
-| AGFHC minihpl | 4 Hours |
+| AGFHC gfx_lvl4 | 1 Hour |
+| AGFHC minihpl | 3 Hours |
 | AGFHC xgmi_lvl1 | 5 Minutes |
 | AGFHC pcie_lvl2 | 10 Minutes |
 | Single Node RCCL | 2 to 11 Minutes |

--- a/docs/network/nic-installation.md
+++ b/docs/network/nic-installation.md
@@ -12,7 +12,9 @@ The firmware and software bundles are available on the AMD Pensando Customer Por
 
 ### Prerequisites
 
-Root access is required for all software and firmware installations. Install host software that is listed in the [AMD Pensando POLLARA Series Installation Guide (UG1716)](https://docs.amd.com/r/en-US/ug1716-pollara-series-installation-guide)
+Root access is required for all software and firmware installations. Install host software that is listed in the [AMD Pensando POLLARA Series Installation Guide (UG1716)](https://docs.amd.com/r/en-US/ug1716-pollara-series-installation-guide).
+
+The Pensando Pollara NIC supports features such as live firmware updates and profile updates, which trigger a PCI reset of the device. If **PCI AER (Advanced Error Reporting) Capability** is enabled in the BIOS, the operating system must be able to handle the resulting link-down notification. If the server does not properly handle this event, please disable PCI AER Capability in the BIOS. Additionally, **Hot Plug support must be enabled** in the BIOS to use profile updates and other reset-related features
 
 #### Download Software
 
@@ -72,15 +74,35 @@ Firmware and software updates are complete.
 
 #### Performance Optimizations
 
-For optimal cluster performance with the Pensando Pollara AI NIC, follow the setup procedures outlined in AMD–Pensando AI-NIC Configuration & Benchmarking, version 1.0.09.16 or later. This document can be obtained through your AMD support representative.
+For optimal cluster performance with the Pensando Pollara AI NIC, follow the setup procedures outlined in the [Pollara 400 Configuration and Benchmarking Guide](https://docs.amd.com/v/u/en-US/ug1813-pollara-400-benchmarking-guide).
 
-Ensure that **Priority Flow Control (PFC)** is enabled and that **Dynamic Congestion Notification Control (DCQCN)** and **Quality of Service (QoS)** are correctly configured. These settings are critical for achieving maximum data throughput and minimizing latency in AI workloads. Please see the scripts provided in AMD–Pensando AI-NIC Configuration & Benchmarking. Exact settings in scripts will need to be modified.
+Ensure that **Priority Flow Control (PFC)** is enabled and that **Dynamic Congestion Notification Control (DCQCN)** and **Quality of Service (QoS)** are correctly configured. These settings are critical for achieving maximum data throughput and minimizing latency in AI workloads. Please see the scripts provided in the Pollara 400 Configuration and Benchmarking Guide. Exact settings in scripts will need to be modified.
+
+Example configuration commands:
+
+```bash
+# Enable RDMA on supporting devices
+$ niccli_rdma_config.sh
+
+# Enable relaxed ordering
+$ niccli_ro_config.sh
+
+# Disable speeds less than 400G
+$ niccli_speedmask.sh
+
+# Disable an unused port (replace <index> with the appropriate port index)
+$ niccli -i <index> link --port_state --set --port_state_param=down
+```
 
 ```{note}
 Configuration settings will not persist through a system power cycle. Reapply all required parameters after each reboot to maintain proper operation. For persistent settings please see the guide to personas at [https://docs.amd.com/r/en-US/ug1717-ai-nic-pollara-400-user-guide/AI-NICPersonas](https://docs.amd.com/r/en-US/ug1717-ai-nic-pollara-400-user-guide/AI-NICPersonas)
 ```
 
 ## Broadcom 400G Network Adapter
+
+For detailed guidance on updating firmware, drivers, and configuring Broadcom network adapters for optimal performance, refer to the [Broadcom Tech Docs Portal](https://techdocs.broadcom.com/). The [Broadcom Ethernet Network Adapter User Guide](https://techdocs.broadcom.com/content/dam/broadcom/techdocs/us/en/pdf/data-center-solutions/netxtreme/EtherNIC-Ctrl-UG2XX.pdf) is a recommended starting point.
+
+To ensure your AI network cluster is configured for maximum efficiency, it is strongly advised to collaborate with Broadcom support personnel during setup and tuning.
 
 For Broadcom 400G NICs, perform the following actions to guarantee proper operation and peak performance:
 
@@ -90,6 +112,25 @@ For Broadcom 400G NICs, perform the following actions to guarantee proper operat
 * Exclude all speeds except 400G from the speed mask.
 * Disable unused ports to optimize resources.
 
+Example configuration commands:
+
+```bash
+# Enable RDMA on supporting devices
+$ niccli_rdma_config.sh
+
+# Enable relaxed ordering
+$ niccli_ro_config.sh
+
+# Disable speeds less than 400G
+$ niccli_speedmask.sh
+
+# Set the performance profile to RoCE (Broadcom exclusive feature)
+$ niccli_set_profile.sh
+
+# Disable an unused port (replace <index> with the appropriate port index)
+$ niccli -i <index> link --port_state --set --port_state_param=down
+```
+
 For detailed configuration, use the scripts provided in the cluster networking GitHub repository.
 
 ## NVIDIA Mellanox CX-7 400Gx1
@@ -97,7 +138,7 @@ For detailed configuration, use the scripts provided in the cluster networking G
 To prevent library incompatibilities that could disrupt system operations, it is necessary to follow the specific installation order:
 
 1. ROCm Installation: The ROCm driver must be installed first, because it sets up essential components and libraries that may otherwise conflict with the versions installed by other drivers.
-2. Mellanox Driver Installation: The Mellanox driver should be installed before the UCX library because it installs an older version of the UCX library.
+2. Mellanox Driver Installation: The Mellanox driver should be installed before the UCX library because it installs an older version of the UCX library. **If UCX was installed previously, please uninstall UCX before installing the Mellanox driver.**
 3. UCX Library Update: Since the Mellanox driver packages an outdated UCX library version, updating the UCX library after completing the Mellanox installation ensures that you are working with the latest features and fixes, thereby maintaining system stability and performance.
 
 ```{note}

--- a/docs/network/rdma-benchmarking.md
+++ b/docs/network/rdma-benchmarking.md
@@ -2,11 +2,11 @@
 
 This section covers essential steps for validating network performance and reliability on AMD Instinct™ platforms. The process includes both software and hardware checks—from enabling RDMA (Remote Direct Memory Access) and verifying link speed to running targeted performance benchmarks and evaluating collective GPU operations. By following the outlined procedures, you can quickly identify and resolve network bottlenecks, ensuring your system delivers optimal performance for high-demand workloads.
 
-## OFED RDMA Perftest
+## OFED Performance Tests
 
 Install and run the [OFED performance tests](https://github.com/linux-rdma/perftest) for GPU to NIC, NIC to switch, and host to host (H2H) testing. Loopback is implemented in the tests to remove the switch from benchmark results.
 
-### Perftest installation
+### Performance Test installation
 
 Remember to install OFED perftests on both nodes you plan to use in this section. Commands may require `sudo` depending on user privileges.
 
@@ -102,6 +102,12 @@ Result:
 
 * PASSED: All paths report average throughput of a 400G NIC as 370 Gbps or greater at some point during the test.
 * FAILED: Unable to reach an average speed equal to or greater than 370 Gbps for a 400G NIC.
+
+### OFED Performance Tests with the Cluster Validation Suite
+
+The OFED Performance Tests can be automated using the [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/).
+
+After [installing the test suite](https://rocm.docs.amd.com/projects/cvs/en/latest/install/cvs-install.html), run the test script as described under the [InfiniBand (IB Perf) test script](https://rocm.docs.amd.com/projects/cvs/en/latest/how-to/run-cvs-tests.html#infiniband-ib-perf-test-script) section.
 
 ## RCCL Benchmarking Results
 

--- a/docs/network/rdma-benchmarking.md
+++ b/docs/network/rdma-benchmarking.md
@@ -36,7 +36,7 @@ Run `make -j && make install`.
 
 Repeat these steps on a second node for when starting multi-node testing.
 
-### Perftest Sanity Test
+### Performance Test Sanity Test
 
 Utilizing commands supported by the perftest suite, various system components can be unit tested. This allows for fast and accurate debugging by isolating the components. Common issues include peer-to-peer enablement, network configuration, transceivers, and cables. A methodical approach checking each component will save time overall.
 
@@ -46,7 +46,7 @@ For performance testing with perftest and RCCL, ACS should be disabled for optim
 
 To temporarily disable ACS, use the script linked at: [dis_acs.sh](https://github.com/ROCm/cluster-networking/blob/main/general_scripts/dis_acs.sh) This change will only take effect on the system until it is rebooted.
 
-#### Perftest GPU to NIC
+#### Performance Test GPU to NIC
 
 Testing the path from the GPU to the NIC to check that there is an optimized peer-to-peer path. This ensures that peer-to-peer RDMA support has been enabled. For accurate testing it is important to use the GPU adjacent to the backend network interface card. All 8 GPUs should be tested to their adjacent NIC.
 
@@ -65,7 +65,7 @@ sudo ./ib_write_bw -x 3 -a -b -F --use_rocm=<GPU Adjacent to NIC 0> -d <NIC 0> -
 * PASSED: All 8 paths report average throughput of 700 Gbps or greater at some point during the test.
 * FAILED: Unable to reach an average speed equal to or greater than 700 Gbps.
 
-#### Perftest NIC to Switch to NIC
+#### Performance Test NIC to Switch to NIC
 
 Testing the path from one NIC to another through the network switch is to ensure that each NIC sends and receives data at the expected speed to validate the NIC, all transceivers, the cable, and the backend switch ports.
 
@@ -85,7 +85,7 @@ sudo ./ib_write_bw -x 3 -a -b -F -d <NIC 1> --report_gbits <host_ip for NIC 0 on
 * PASSED: All paths report average throughput of a 400G NIC as 380 Gbps or greater at some point during the test.
 * FAILED: Unable to reach an average speed equal to or greater than 380 Gbps for a 400G NIC.
 
-#### Perftest GPU to GPU through the Switch
+#### Performance Test GPU to GPU through the Switch
 
 Run the following set of commands 16 times, once to check the send path and once to check the receive path GPU though the NIC out to the switch is valid. A second node is needed for this test since data will be routed locally over the PCIe bus if a single node is used. This will ensure that all NICs are functioning properly and that the connection to the supporting network switch is valid.
 

--- a/docs/network/rdma-benchmarking.md
+++ b/docs/network/rdma-benchmarking.md
@@ -62,8 +62,8 @@ sudo ./ib_write_bw -x 3 -a -b -F --use_rocm=<GPU Adjacent to NIC 0> -d <NIC 0> -
 
 ##### Result
 
-* PASSED: All 8 paths report average throughput of 700 Gbps or greater at some point during the test.
-* FAILED: Unable to reach an average speed equal to or greater than 700 Gbps.
+* PASSED: All 8 paths report average throughput of 390 Gbps or greater at some point during the test.
+* FAILED: Unable to reach an average speed equal to or greater than 390 Gbps.
 
 #### Performance Test NIC to Switch to NIC
 
@@ -80,10 +80,14 @@ sudo ./ib_write_bw -x 3 -a -b -F -d <NIC 0> --report_gbits
 sudo ./ib_write_bw -x 3 -a -b -F -d <NIC 1> --report_gbits <host_ip for NIC 0 on node 0>
 ```
 
+```{note}
+If you receive "Unable to open file descriptor for socket connection" relating to port 18515, please disable the firewall.
+```
+
 ##### Result
 
-* PASSED: All paths report average throughput of a 400G NIC as 380 Gbps or greater at some point during the test.
-* FAILED: Unable to reach an average speed equal to or greater than 380 Gbps for a 400G NIC.
+* PASSED: All paths report average throughput of a 400G NIC as 770 Gbps or greater at some point during the test.
+* FAILED: Unable to reach an average speed equal to or greater than 770 Gbps for a 400G NIC.
 
 #### Performance Test GPU to GPU through the Switch
 
@@ -100,8 +104,8 @@ sudo ./ib_write_bw -x 3 -a -b -F --use_rocm=<GPU Adjacent to NIC 1> -d <NIC 1> -
 
 Result:
 
-* PASSED: All paths report average throughput of a 400G NIC as 370 Gbps or greater at some point during the test.
-* FAILED: Unable to reach an average speed equal to or greater than 370 Gbps for a 400G NIC.
+* PASSED: All paths report average throughput of a 400G NIC as 770 Gbps or greater at some point during the test.
+* FAILED: Unable to reach an average speed equal to or greater than 770 Gbps for a 400G NIC.
 
 ### OFED Performance Tests with the Cluster Validation Suite
 

--- a/docs/network/topology-mapping.md
+++ b/docs/network/topology-mapping.md
@@ -25,7 +25,7 @@ Record the output for mapping purposes; this will be needed later to confirm the
 Run the following command to determine the GPU number for each of the BDF listed from the previous command.
 
 ```bash
-amd-smi list | grep -e "BDF" -e "GPU"
+sudo amd-smi list | grep -e "BDF" -e "GPU"
 ```
 
 ### Determine the PCIe Bus Topology for Each GPU

--- a/docs/network/validation.md
+++ b/docs/network/validation.md
@@ -1,4 +1,12 @@
-# Network Validation
+# Network and Cluster Validation
+
+This chapter details validation of the network and the cluster. Validating network performance and reliability for AMD Instinct™ platforms is essential to ensure optimal data throughput and cluster efficiency.
+
+This section outlines pre-validation checks, such as enabling RDMA on backend NICs and verifying link speeds, with 400G NICs recommended for avoiding bottlenecks. The chapter also details the installation and execution of Open Fabrics Enterprise Distribution (OFED) performance tests to validate GPU-to-NIC, NIC-to-switch, and host-to-host communication, including specific tests for GPU-to-GPU and NIC-to-switch paths. Disabling ACS is advised for consistent performance during testing.
+
+Multi-node RCCL tests are introduced to verify inter-node GPU communication, with automation options available via the Cluster Validation Suite. The chapter then transitions to cluster validation, establishing performance baselines and guiding further optimization. It recommends AI model validation using benchmarks like Llama 3.1 and provides resources for multi-node network performance validation, emphasizing workload tuning for enhanced efficiency on AMD Instinct™ systems.
+
+## Network Validation
 
 This section covers essential steps for validating network performance and reliability on AMD Instinct™ platforms. Proper network validation is critical, as misconfigured settings or faulty hardware can significantly impact data throughput and cluster efficiency. The process includes both software and hardware checks—from enabling RDMA (Remote Direct Memory Access) and verifying link speed to running targeted performance benchmarks and evaluating collective GPU operations. By following the outlined procedures, you can quickly identify and resolve network bottlenecks, ensuring your system delivers optimal performance for high-demand workloads.
 
@@ -47,3 +55,73 @@ cat /sys/class/net/<interface>/speed
 
 * PASSED: All backend NICs report a speed of 400000
 * FAILED: Any result less than 400000
+
+## RCCL Multi-Node Fabric Test
+
+Multi-node RCCL testing verifies that GPUs in one node can communicate correctly and efficiently with GPUs in other nodes in the cluster, ensuring that the communication fabric is functioning properly. An overview of RCCL, along with configuration instructions, is provided in the [RCCL Benchmarking](../common/rccl-benchmarking.md) section. It is generally recommended to run this test on a subset of the deployment, either the full cluster or up to sixteen nodes, whichever is smaller.
+
+### RCCL Pre-Checks
+
+To ensure that RCCL runs properly, please ensure that the following criteria are met:
+
+1. Ensure that UCX, OpenMPI, RCCL-Tests and AMD ANP are built using the options given in this document.
+2. Run a fabric ping test and ensure reachability.
+3. Configure PFC and DCQCN with recommended parameters.
+4. Ensure QoS (PFC + DCQCN) is configured across the network and DSCP marking at NICs and Switches are in sync.
+5. Set ulimit value to infinite.
+6. Run OFED Performance Tests, CPU-to-CPU and GPU-to-GPU, across the cluster.
+7. Disable ACS. Performance will vary dramatically if ACS is enabled.
+
+### RCCL Multi-Node Test
+
+Refer to the [RCCL Benchmarking](../common/rccl-benchmarking.md) page for detailed instructions on building and running multi-node RCCL tests.
+
+**Result:**
+
+* PASSED: For a two node cluster, Allreduce performance of 304 GB/s or greater for MI300X. For a two node cluster, Allreduce performance of 350 GB/s or greater for MI350X or MI355X.
+* FAILED: Allreduce performance less than expected values.
+
+### RCCL Multi-Node Tests with the Cluster Validation Suite
+
+The multi-node RCCL test recommended for deployment can be automated using the [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/).
+
+Before running CVS, ensure that the configuration files for your specific platform and the nodes under test are correctly defined in the `cvs/input/config_file/` subdirectories.
+
+After [installing the test suite](https://rocm.docs.amd.com/projects/cvs/en/latest/install/cvs-install.html), deploy RCCL to the cluster using:
+
+```bash
+pytest -vvv --log-file=/tmp/test.log -s ./tests/rccl/rccl_multinode_cvs.py \
+  --cluster_file input/cluster_file/cluster.json \
+  --config_file input/config_file/rccl/rccl_config.json \
+  --html=/var/www/html/cvs/rccl.html --capture=tee-sys --self-contained-html
+```
+
+## Cluster Validation
+
+After successfully completing the tests mentioned in this guide, the System Under Test (SUT) meets the single-node customer acceptance criteria. The test results related to performance serve as a baseline for further enhancements. To further optimize the system, make incremental changes to individual parameters noted in the prerequisites and repeat the tests. Once complete, proceed with AI model validation and cluster network validation using the guides mentioned below.
+
+### Cluster Network Performance Validation
+
+After validating single-node performance, configure each server for maximum data transfer and bandwidth. It is essential to test both host and device performance in single-node and multi-node setups using targeted benchmarks.
+
+The [Cluster Network Performance Validation Guide](https://rocm.docs.amd.com/projects/gpu-cluster-networking/en/latest/) for single-node and multi-node networking provides step-by-step instructions on configuring network settings, devices, and running performance tests to ensure AMD Instinct™-based GPU clusters operate at peak speed and bandwidth.
+
+Use the guides as follows:
+
+1. Validate and optimize a single server using the [Single Node Configuration](https://instinct.docs.amd.com/projects/gpu-cluster-networking/en/latest/how-to/single-node-config.html) section of the GPU Cluster Networking guide.
+2. If you are using a RoCE network, consult the [RoCE Network Configuration Guide](https://instinct.docs.amd.com/projects/gpu-cluster-networking/en/latest/how-to/roce-network-config.html) for additional steps pertaining to your hardware. Otherwise, proceed to step 3.
+3. Once all individual nodes are validated, proceed through the [Multi-node Networking Guide](https://instinct.docs.amd.com/projects/gpu-cluster-networking/en/latest/how-to/multi-node-config.html). If you did not install MPI-supported rccl-tests in the [RCCL Benchmarking](../common/rccl-benchmarking.md) section, ensure you do so when following the multi-node guide.
+
+To thoroughly evaluate your cluster's performance, we recommend using the Llama 3.1 405B training benchmark with the JAX library. Please note that the runtime will vary depending on the number of nodes, NICs per node, and overall cluster configuration.
+
+There is no multi-node inference benchmark suggested to evaluate clusters at this time, but use of vLLM and SGLang should be considered.
+
+### AI Workload Validation with the Cluster Validation Suite
+
+AMD recommends using the workload of Llama 3.1 405B with JAX for multi-node testing.
+
+The [Cluster Validation Suite](https://rocm.docs.amd.com/projects/cvs/en/latest/) includes scripts for automatically installing and running this workload as part of deployment testing. Additional documentation is available on the ROCm website under *Run Cluster Validation Suite Tests* page, within the [Jax training test scripts](https://rocm.docs.amd.com/projects/cvs/en/latest/how-to/run-cvs-tests.html#jax-training-test-scripts) section.
+
+### Workload Optimization
+
+Once the system and networking have been fully validated, review the [Workload Optimization Guide](https://rocm.docs.amd.com/projects/gpu-cluster-networking/en/latest/how-to/workload-optimization.html) to learn more about how to tune workloads for maximum performance on AMD Instinct™ systems.

--- a/docs/network/validation.md
+++ b/docs/network/validation.md
@@ -22,6 +22,34 @@ All the backend network interfaces should support RDMA. To ensure it is enabled 
 rdma link
 ```
 
+Example output for Broadcom NICs:
+
+```bash
+link bnxt_re0/1 state ACTIVE physical_state LINK_UP netdev ens26np0
+link bnxt_re1/1 state ACTIVE physical_state LINK_UP netdev ens27np0
+link bnxt_re2/1 state ACTIVE physical_state LINK_UP netdev ens25np0
+link bnxt_re3/1 state ACTIVE physical_state LINK_UP netdev ens24np0
+link bnxt_re4/1 state ACTIVE physical_state LINK_UP netdev ens22np0
+link bnxt_re5/1 state ACTIVE physical_state LINK_UP netdev ens23np0
+link bnxt_re6/1 state ACTIVE physical_state LINK_UP netdev ens21np0
+link bnxt_re7/1 state ACTIVE physical_state LINK_UP netdev ens20np0
+```
+
+For Mellanox NICs, the RDMA device names would be `mlx5_0`, `mlx5_1`, etc.
+
+Example output for AMD Pensando (AINIC) NICs:
+
+```bash
+link ionic_0/1 state ACTIVE physical_state LINK_UP netdev benic7p1
+link ionic_1/1 state ACTIVE physical_state LINK_UP netdev benic8p1
+link ionic_2/1 state ACTIVE physical_state LINK_UP netdev benic6p1
+link ionic_3/1 state ACTIVE physical_state LINK_UP netdev benic5p1
+link ionic_4/1 state ACTIVE physical_state LINK_UP netdev benic3p1
+link ionic_5/1 state ACTIVE physical_state LINK_UP netdev benic2p1
+link ionic_6/1 state ACTIVE physical_state LINK_UP netdev benic1p1
+link ionic_7/1 state ACTIVE physical_state LINK_UP netdev benic4p1
+```
+
 Result:
 
 * PASSED: All 8 backend NICs should be listed and report status as ENABLED.
@@ -29,7 +57,7 @@ Result:
 
 ### Check NIC Link Speed
 
-Verify the NICs in your servers are reporting the correct speeds. Several commands and utilities are available to measure speed based on your network type. For the AMD Instinct™ product line 400G network cards are generally advised. 200G cards are not sufficient to avoid bottlenecks and 800G cards and not needed.
+Verify the NICs in your servers are reporting the correct speeds. Several commands and utilities are available to measure speed based on your network type. For the AMD Instinct™ product line 400G network cards are generally advised. 200G cards are not sufficient to avoid bottlenecks and 800G cards are not needed.
 
 #### RoCE / Ethernet
 
@@ -64,7 +92,7 @@ Multi-node RCCL testing verifies that GPUs in one node can communicate correctly
 
 To ensure that RCCL runs properly, please ensure that the following criteria are met:
 
-1. Ensure that UCX, OpenMPI, RCCL-Tests and AMD ANP are built using the options given in this document.
+1. Ensure that UCX, OpenMPI, and RCCL-Tests are built using the options given in this document. For systems using Pensando NICs the AMD ANP should also be rebuilt.
 2. Run a fabric ping test and ensure reachability.
 3. Configure PFC and DCQCN with recommended parameters.
 4. Ensure QoS (PFC + DCQCN) is configured across the network and DSCP marking at NICs and Switches are in sync.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -13,10 +13,12 @@ subtrees:
       - file: common/prerequisites.md
       - file: common/bios-settings.md
       - file: common/kernel-parameters.md
-      - file: common/system-setup.md      
-      - file: common/health-checks.md      
+      - file: common/system-setup.md
+      - file: common/health-checks.md
       - file: common/os-tuning.md
       - file: common/system-validation.md
+      - file: common/rccl-benchmarking.md
+      - file: common/workload-validation.md
       - file: common/firmware-updates.md      
 
   - caption: Cluster Networking


### PR DESCRIPTION
Updates documentation to v1.2.1 of the Cluster Acceptance Guide. This PR includes the v1.2 changes (originally committed in January 2026) plus the v1.2 → v1.2.1 delta.

## v1.2 changes (previously committed)

- BIOS settings: Reorganized into 4 categorized tables (Required, Virtualization, Non-virtualization, Performance); added GMI Folding setting
- CVS integration: Added automation sections for health checks, AGFHC, RCCL, and AI workloads
- New pages: rccl-benchmarking.md (single-node RCCL testing), workload-validation.md (AI model performance)
- Testing overview: Added test duration tables and CVS introduction to index page
- Network docs: Expanded NIC installation guidance for Pensando/Broadcom; renamed OFED sections; added RCCL multi-node and cluster validation sections
- Kernel parameters: Clarified Ubuntu/RHEL instructions; marked numa_balancing and modprobe.blacklist as optional

## v1.2.1 changes (new commits)

### AGFHC validation updates
- New `gfx_lvl4` GPU thermal stress test recipe with full documentation
- Restructured `hbm_lvl5` as 4 separate runs with `sleep 300` between each (for silicon contraction testing)
- Updated `minihpl` minimum duration from 4 hours to 3 hours
- Updated AGFHC test commands table with expanded test sequence
- Renamed duration column to "Estimated Test Duration / Rationale"
- Updated total test time estimates

### RDMA performance thresholds
- GPU-to-NIC pass threshold: 700 → 390 Gbps
- NIC-to-switch pass threshold: 380 → 770 Gbps
- GPU-to-GPU through switch threshold: 370 → 770 Gbps
- Added firewall note for port 18515 socket connection errors

### Network validation
- Added `rdma link` output examples for Broadcom, Mellanox, and Pensando NICs
- Updated RCCL pre-checks: AMD ANP moved to Pensando-specific note
- Fixed typo: "800G cards and not needed" → "are not needed"

### Minor fixes
- Fixed en-dash to double-dash in `--list` command