### PR TITLE
Add cluster acceptance checklist to MI350X and MI355X pages

### DIFF
--- a/docs/common/system-validation.md
+++ b/docs/common/system-validation.md
@@ -832,9 +832,8 @@ The tables below list the recommended and suggested AGFHC validation recipes alo
 | gfx_lvl4 | All AMD MI3xx Instinct™ models | 1 Hour | GPU stress test to hot spot test GPU needed for DLC systems |
 | sleep 300 sec. | | 5 Minutes, sixth iteration | For silicon to contract to widen any cracks |
 | minihpl | All AMD MI3xx Instinct™ models | 3 Hours | Search for voltage failures and stress HBM |
-| xgmi_lvl1 | All AMD MI3xx Instinct™ models | 5 Minutes | Check for link degradation |
 | pcie_lvl2 | All AMD MI3xx Instinct™ models | 10 Minutes | Check for link degradation |
-| Total | | | 14 Hours and 45 Minutes |
+| Total | | | 14 Hours and 40 Minutes |
 
 #### Recommended AGFHC Tests
 

--- a/docs/gpus/mi350x.md
+++ b/docs/gpus/mi350x.md
@@ -52,15 +52,19 @@ Example (truncated for brevity – expect 8 lines):
 f5:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a0
 ```
 
-## Acceptance Criteria
+## Acceptance Criteria Checklist
 
-The MI350X system acceptance process validates that the platform is correctly configured, stable, and performing to expectations. Follow the sequence: Prerequisites → Basic Health Checks → System Validation (AGFHC recipes) → Performance Benchmarks.
+This section presents the high-level cluster acceptance validation criteria in a clear, checklist-driven format designed to enable efficient tracking and execution. The checklist is used to verify that the system meets all required technical, operational, and performance criteria necessary to achieve "Go-Live" readiness. Each item is hyperlinked to the corresponding section in this document, allowing users to quickly access detailed procedures, execution steps, and supporting guidance as needed.
+
+The single-node and multi-node validation tests require defined minimum execution (run) times to ensure that testing is performed under appropriate conditions to accurately evaluate system stability, performance, and reliability.
+
+Successful completion of this checklist confirms that the cluster has been properly configured, validated at both the single-node and multi-node levels, and can support sustained AI workloads in a production environment. All validation steps must be completed without error, and supporting logs must be retained as evidence prior to final acceptance, handover, and deployment.
 
 ### System Acceptance Process
 
 1. **[Prerequisites Validation](#prerequisites-validation)** - Ensure all system requirements and dependencies are met
 2. **[Basic Health Checks](#basic-health-checks)** - Verify hardware detection and basic system health
-3. **[System Validation](#system-validation)** - Conduct comprehensive stress testing and qualification
+3. **[System Validation](#system-validation)** - Conduct comprehensive single and multi-node stress testing and qualification
 4. **[Performance Benchmarks](#performance-benchmarks)** - Validate compute, memory, and interconnect performance
 
 System is accepted when all required recipe runs and benchmarks pass without errors and no hardware faults appear in logs.
@@ -101,12 +105,28 @@ These checks ensure fundamental system health and proper GPU detection. For deta
 
 AGFHC (AMD GPU Field Health Check) provides structured recipes exercising PCIe, HBM, compute, power/thermal and fabric.
 
-| Recipe | Command | Purpose | Pass Criteria |
-|--------|---------|---------|---------------|
-| [all_lvl5](../common/system-validation.md#all_lvl5) | `/opt/amd/agfhc/agfhc -r all_lvl5 -o <output_dir>` | Broad ~2h system-level coverage (PCIe, HBM, compute, power) | Overall result PASS / return code 0 |
-| [hbm_lvl5](../common/system-validation.md#hbm_lvl5) (run twice) | `/opt/amd/agfhc/agfhc -r hbm_lvl5:i=2 -o <output_dir>` | Intensive HBM stress & ECC observation | Both iterations PASS / no memory errors |
-| [pcie_lvl2](../common/system-validation.md#pcie_lvl2) | `/opt/amd/agfhc/agfhc -r pcie_lvl2 -o <output_dir>` | PCIe bandwidth & link health | PASS / expected link stability |
-| [miniHPL](../common/system-validation.md#minihpl) (optional) | `/opt/amd/agfhc/agfhc -t miniHPL:d=120m -o <output_dir>` | Linpack-like integration stress (MI350X) | PASS / completes without failures |
+#### Single-Node Tests
+
+Following single-node tests must be performed at the required run time with no failures reported in validation logs.
+
+| Recipe | Command | Run Time | Purpose | Pass Criteria |
+|--------|---------|----------|---------|---------------|
+| [all_lvl5](../common/system-validation.md#all_lvl5) | `/opt/amd/agfhc/agfhc -r all_lvl5 -o <output_dir>` | 2 hours | Broad system-level coverage (PCIe, HBM, compute, power) | Overall result PASS / return code 0 |
+| [hbm_lvl5](../common/system-validation.md#hbm_lvl5) (4 iterations) | `/opt/amd/agfhc/agfhc -r hbm_lvl5:i=4 -o <output_dir>` | 8 hours | Intensive HBM stress & ECC observation | All iterations PASS / no memory errors |
+| [gfx_lvl4](../common/system-validation.md#gfx_lvl4) | `/opt/amd/agfhc/agfhc -r gfx_lvl4 -o <output_dir>` | 1 hour | GPU compute stress test | PASS / return code 0 |
+| [miniHPL](../common/system-validation.md#minihpl) | `/opt/amd/agfhc/agfhc -t minihpl:d=3h -o <output_dir>` | 3 hours | Linpack-like integration stress | PASS / completes without failures |
+| [pcie_lvl2](../common/system-validation.md#pcie_lvl2) | `/opt/amd/agfhc/agfhc -r pcie_lvl2 -o <output_dir>` | 10 minutes | PCIe bandwidth & link health | PASS / expected link stability |
+| [Single-node RCCL](../common/rccl-benchmarking.md#single-node-rccl-testing) | `all_reduce_perf -b 8 -e 8G -f 2 -g 8` | 2–11 minutes | Single-node GPU interconnect validation | busbw meets expected thresholds |
+
+#### Multi-Node Tests
+
+Following multi-node tests must be performed at the required run time with no failures reported in validation logs.
+
+| Test | Reference | Run Time | Purpose | Pass Criteria |
+|------|-----------|----------|---------|---------------|
+| [OFED Performance Tests](../network/rdma-benchmarking.md#ofed-performance-tests) | Network validation | 2 hours | RDMA fabric bandwidth and latency | All tests PASS / expected bandwidth |
+| [Multi-node RCCL](../network/validation.md#rccl-multi-node-fabric-test) | Network validation | Up to 128 nodes, 10 hours | Multi-node GPU fabric validation | All nodes PASS / expected bandwidth |
+| [AI Workloads](../network/validation.md#ai-workload-validation-with-the-cluster-validation-suite) | Cluster validation | 24 hours | Sustained AI workload (Llama 3.1 405B with JAX) | Completes without failures |
 
 Review `results.json` in the output directory or terminal summary; any FAIL requires remediation before acceptance.
 

--- a/docs/gpus/mi350x.md
+++ b/docs/gpus/mi350x.md
@@ -54,20 +54,18 @@ f5:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 7
 
 ## Acceptance Criteria Checklist
 
-This section presents the high-level cluster acceptance validation criteria in a clear, checklist-driven format designed to enable efficient tracking and execution. The checklist is used to verify that the system meets all required technical, operational, and performance criteria necessary to achieve "Go-Live" readiness. Each item is hyperlinked to the corresponding section in this document, allowing users to quickly access detailed procedures, execution steps, and supporting guidance as needed.
-
-The single-node and multi-node validation tests require defined minimum execution (run) times to ensure that testing is performed under appropriate conditions to accurately evaluate system stability, performance, and reliability.
-
-Successful completion of this checklist confirms that the cluster has been properly configured, validated at both the single-node and multi-node levels, and can support sustained AI workloads in a production environment. All validation steps must be completed without error, and supporting logs must be retained as evidence prior to final acceptance, handover, and deployment.
-
-### System Acceptance Process
+This section presents the high-level cluster acceptance validation criteria in a clear, checklist-driven format designed to enable efficient execution and tracking. The checklist is used to verify that the system meets all required technical, operational, and performance criteria necessary to achieve "Go-Live" readiness. It is organized into the following key areas:
 
 1. **[Prerequisites Validation](#prerequisites-validation)** - Ensure all system requirements and dependencies are met
 2. **[Basic Health Checks](#basic-health-checks)** - Verify hardware detection and basic system health
 3. **[System Validation](#system-validation)** - Conduct comprehensive single and multi-node stress testing and qualification
 4. **[Performance Benchmarks](#performance-benchmarks)** - Validate compute, memory, and interconnect performance
 
-System is accepted when all required recipe runs and benchmarks pass without errors and no hardware faults appear in logs.
+Each area consists of a defined set of criteria that are hyperlinked to the corresponding sections within this guide, enabling users to quickly access detailed procedures, execution steps, and supporting guidance.
+
+The System Validation area, which includes both single-node and multi-node testing, defines minimum required execution (run) times for each test. These requirements ensure that validation is conducted under appropriate conditions to accurately assess system stability, performance, and reliability.
+
+Successful completion of this checklist, with no errors or hardware faults observed in validation logs, confirms that the cluster has been properly configured, validated at both the single-node and multi-node levels, and is capable of supporting sustained AI workloads in a production environment.
 
 ### Prerequisites Validation
 
@@ -114,9 +112,10 @@ Following single-node tests must be performed at the required run time with no f
 | [all_lvl5](../common/system-validation.md#all_lvl5) | `/opt/amd/agfhc/agfhc -r all_lvl5 -o <output_dir>` | 2 hours | Broad system-level coverage (PCIe, HBM, compute, power) | Overall result PASS / return code 0 |
 | [hbm_lvl5](../common/system-validation.md#hbm_lvl5) (4 iterations) | `/opt/amd/agfhc/agfhc -r hbm_lvl5:i=4 -o <output_dir>` | 8 hours | Intensive HBM stress & ECC observation | All iterations PASS / no memory errors |
 | [gfx_lvl4](../common/system-validation.md#gfx_lvl4) | `/opt/amd/agfhc/agfhc -r gfx_lvl4 -o <output_dir>` | 1 hour | GPU compute stress test | PASS / return code 0 |
-| [miniHPL](../common/system-validation.md#minihpl) | `/opt/amd/agfhc/agfhc -t minihpl:d=3h -o <output_dir>` | 3 hours | Linpack-like integration stress | PASS / completes without failures |
+| [miniHPL](../common/system-validation.md#minihpl) | `/opt/amd/agfhc/agfhc -t minihpl:d=3h -o <output_dir>` | 3 hours (10 hours recommended) | Linpack-like integration stress | PASS / completes without failures |
 | [pcie_lvl2](../common/system-validation.md#pcie_lvl2) | `/opt/amd/agfhc/agfhc -r pcie_lvl2 -o <output_dir>` | 10 minutes | PCIe bandwidth & link health | PASS / expected link stability |
 | [Single-node RCCL](../common/rccl-benchmarking.md#single-node-rccl-testing) | `all_reduce_perf -b 8 -e 8G -f 2 -g 8` | 2–11 minutes | Single-node GPU interconnect validation | busbw meets expected thresholds |
+| [AI Workloads](../network/validation.md#ai-workload-validation-with-the-cluster-validation-suite) | See workload validation | 1–24 hours | Sustained AI workload (Llama 3.1 70B with JAX) | Completes without failures |
 
 #### Multi-Node Tests
 

--- a/docs/gpus/mi355x.md
+++ b/docs/gpus/mi355x.md
@@ -54,20 +54,18 @@ f5:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 7
 
 ## Acceptance Criteria Checklist
 
-This section presents the high-level cluster acceptance validation criteria in a clear, checklist-driven format designed to enable efficient tracking and execution. The checklist is used to verify that the system meets all required technical, operational, and performance criteria necessary to achieve "Go-Live" readiness. Each item is hyperlinked to the corresponding section in this document, allowing users to quickly access detailed procedures, execution steps, and supporting guidance as needed.
-
-The single-node and multi-node validation tests require defined minimum execution (run) times to ensure that testing is performed under appropriate conditions to accurately evaluate system stability, performance, and reliability.
-
-Successful completion of this checklist confirms that the cluster has been properly configured, validated at both the single-node and multi-node levels, and can support sustained AI workloads in a production environment. All validation steps must be completed without error, and supporting logs must be retained as evidence prior to final acceptance, handover, and deployment.
-
-### System Acceptance Process
+This section presents the high-level cluster acceptance validation criteria in a clear, checklist-driven format designed to enable efficient execution and tracking. The checklist is used to verify that the system meets all required technical, operational, and performance criteria necessary to achieve "Go-Live" readiness. It is organized into the following key areas:
 
 1. **[Prerequisites Validation](#prerequisites-validation)** - Ensure all system requirements and dependencies are met
 2. **[Basic Health Checks](#basic-health-checks)** - Verify hardware detection and basic system health
 3. **[System Validation](#system-validation)** - Conduct comprehensive single and multi-node stress testing and qualification
 4. **[Performance Benchmarks](#performance-benchmarks)** - Validate compute, memory, and interconnect performance
 
-System is accepted when all required recipe runs and benchmarks pass without errors and no hardware faults appear in logs.
+Each area consists of a defined set of criteria that are hyperlinked to the corresponding sections within this guide, enabling users to quickly access detailed procedures, execution steps, and supporting guidance.
+
+The System Validation area, which includes both single-node and multi-node testing, defines minimum required execution (run) times for each test. These requirements ensure that validation is conducted under appropriate conditions to accurately assess system stability, performance, and reliability.
+
+Successful completion of this checklist, with no errors or hardware faults observed in validation logs, confirms that the cluster has been properly configured, validated at both the single-node and multi-node levels, and is capable of supporting sustained AI workloads in a production environment.
 
 ### Prerequisites Validation
 
@@ -114,9 +112,10 @@ Following single-node tests must be performed at the required run time with no f
 | [all_lvl5](../common/system-validation.md#all_lvl5) | `/opt/amd/agfhc/agfhc -r all_lvl5 -o <output_dir>` | 2 hours | Broad system-level coverage (PCIe, HBM, compute, power) | Overall result PASS / return code 0 |
 | [hbm_lvl5](../common/system-validation.md#hbm_lvl5) (4 iterations) | `/opt/amd/agfhc/agfhc -r hbm_lvl5:i=4 -o <output_dir>` | 8 hours | Intensive HBM stress & ECC observation | All iterations PASS / no memory errors |
 | [gfx_lvl4](../common/system-validation.md#gfx_lvl4) | `/opt/amd/agfhc/agfhc -r gfx_lvl4 -o <output_dir>` | 1 hour | GPU compute stress test | PASS / return code 0 |
-| [miniHPL](../common/system-validation.md#minihpl) | `/opt/amd/agfhc/agfhc -t minihpl:d=3h -o <output_dir>` | 3 hours | Linpack-like integration stress | PASS / completes without failures |
+| [miniHPL](../common/system-validation.md#minihpl) | `/opt/amd/agfhc/agfhc -t minihpl:d=3h -o <output_dir>` | 3 hours (10 hours recommended) | Linpack-like integration stress | PASS / completes without failures |
 | [pcie_lvl2](../common/system-validation.md#pcie_lvl2) | `/opt/amd/agfhc/agfhc -r pcie_lvl2 -o <output_dir>` | 10 minutes | PCIe bandwidth & link health | PASS / expected link stability |
 | [Single-node RCCL](../common/rccl-benchmarking.md#single-node-rccl-testing) | `all_reduce_perf -b 8 -e 8G -f 2 -g 8` | 2–11 minutes | Single-node GPU interconnect validation | busbw meets expected thresholds |
+| [AI Workloads](../network/validation.md#ai-workload-validation-with-the-cluster-validation-suite) | See workload validation | 1–24 hours | Sustained AI workload (Llama 3.1 70B with JAX) | Completes without failures |
 
 #### Multi-Node Tests
 

--- a/docs/gpus/mi355x.md
+++ b/docs/gpus/mi355x.md
@@ -52,15 +52,19 @@ Example (truncated for brevity – expect 8 lines):
 f5:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
 ```
 
-## Acceptance Criteria
+## Acceptance Criteria Checklist
 
-The MI355X system acceptance process validates that the platform is correctly configured, stable, and performing to expectations. Follow the sequence: Prerequisites → Basic Health Checks → System Validation (AGFHC recipes) → Performance Benchmarks.
+This section presents the high-level cluster acceptance validation criteria in a clear, checklist-driven format designed to enable efficient tracking and execution. The checklist is used to verify that the system meets all required technical, operational, and performance criteria necessary to achieve "Go-Live" readiness. Each item is hyperlinked to the corresponding section in this document, allowing users to quickly access detailed procedures, execution steps, and supporting guidance as needed.
+
+The single-node and multi-node validation tests require defined minimum execution (run) times to ensure that testing is performed under appropriate conditions to accurately evaluate system stability, performance, and reliability.
+
+Successful completion of this checklist confirms that the cluster has been properly configured, validated at both the single-node and multi-node levels, and can support sustained AI workloads in a production environment. All validation steps must be completed without error, and supporting logs must be retained as evidence prior to final acceptance, handover, and deployment.
 
 ### System Acceptance Process
 
 1. **[Prerequisites Validation](#prerequisites-validation)** - Ensure all system requirements and dependencies are met
 2. **[Basic Health Checks](#basic-health-checks)** - Verify hardware detection and basic system health
-3. **[System Validation](#system-validation)** - Conduct comprehensive stress testing and qualification
+3. **[System Validation](#system-validation)** - Conduct comprehensive single and multi-node stress testing and qualification
 4. **[Performance Benchmarks](#performance-benchmarks)** - Validate compute, memory, and interconnect performance
 
 System is accepted when all required recipe runs and benchmarks pass without errors and no hardware faults appear in logs.
@@ -101,12 +105,28 @@ These checks ensure fundamental system health and proper GPU detection. For deta
 
 AGFHC (AMD GPU Field Health Check) provides structured recipes exercising PCIe, HBM, compute, power/thermal and fabric.
 
-| Recipe | Command | Purpose | Pass Criteria |
-|--------|---------|---------|---------------|
-| [all_lvl5](../common/system-validation.md#all_lvl5) | `/opt/amd/agfhc/agfhc -r all_lvl5 -o <output_dir>` | Broad ~2h system-level coverage (PCIe, HBM, compute, power) | Overall result PASS / return code 0 |
-| [hbm_lvl5](../common/system-validation.md#hbm_lvl5) (run twice) | `/opt/amd/agfhc/agfhc -r hbm_lvl5:i=2 -o <output_dir>` | Intensive HBM stress & ECC observation | Both iterations PASS / no memory errors |
-| [pcie_lvl2](../common/system-validation.md#pcie_lvl2) | `/opt/amd/agfhc/agfhc -r pcie_lvl2 -o <output_dir>` | PCIe bandwidth & link health | PASS / expected link stability |
-| [miniHPL](../common/system-validation.md#minihpl) (optional) | `/opt/amd/agfhc/agfhc -t miniHPL:d=120m -o <output_dir>` | Linpack-like integration stress (MI355X) | PASS / completes without failures |
+#### Single-Node Tests
+
+Following single-node tests must be performed at the required run time with no failures reported in validation logs.
+
+| Recipe | Command | Run Time | Purpose | Pass Criteria |
+|--------|---------|----------|---------|---------------|
+| [all_lvl5](../common/system-validation.md#all_lvl5) | `/opt/amd/agfhc/agfhc -r all_lvl5 -o <output_dir>` | 2 hours | Broad system-level coverage (PCIe, HBM, compute, power) | Overall result PASS / return code 0 |
+| [hbm_lvl5](../common/system-validation.md#hbm_lvl5) (4 iterations) | `/opt/amd/agfhc/agfhc -r hbm_lvl5:i=4 -o <output_dir>` | 8 hours | Intensive HBM stress & ECC observation | All iterations PASS / no memory errors |
+| [gfx_lvl4](../common/system-validation.md#gfx_lvl4) | `/opt/amd/agfhc/agfhc -r gfx_lvl4 -o <output_dir>` | 1 hour | GPU compute stress test | PASS / return code 0 |
+| [miniHPL](../common/system-validation.md#minihpl) | `/opt/amd/agfhc/agfhc -t minihpl:d=3h -o <output_dir>` | 3 hours | Linpack-like integration stress | PASS / completes without failures |
+| [pcie_lvl2](../common/system-validation.md#pcie_lvl2) | `/opt/amd/agfhc/agfhc -r pcie_lvl2 -o <output_dir>` | 10 minutes | PCIe bandwidth & link health | PASS / expected link stability |
+| [Single-node RCCL](../common/rccl-benchmarking.md#single-node-rccl-testing) | `all_reduce_perf -b 8 -e 8G -f 2 -g 8` | 2–11 minutes | Single-node GPU interconnect validation | busbw meets expected thresholds |
+
+#### Multi-Node Tests
+
+Following multi-node tests must be performed at the required run time with no failures reported in validation logs.
+
+| Test | Reference | Run Time | Purpose | Pass Criteria |
+|------|-----------|----------|---------|---------------|
+| [OFED Performance Tests](../network/rdma-benchmarking.md#ofed-performance-tests) | Network validation | 2 hours | RDMA fabric bandwidth and latency | All tests PASS / expected bandwidth |
+| [Multi-node RCCL](../network/validation.md#rccl-multi-node-fabric-test) | Network validation | Up to 128 nodes, 10 hours | Multi-node GPU fabric validation | All nodes PASS / expected bandwidth |
+| [AI Workloads](../network/validation.md#ai-workload-validation-with-the-cluster-validation-suite) | Cluster validation | 24 hours | Sustained AI workload (Llama 3.1 405B with JAX) | Completes without failures |
 
 Review `results.json` in the output directory or terminal summary; any FAIL requires remediation before acceptance.
 


### PR DESCRIPTION
## Summary

- Renames "Acceptance Criteria" to "Acceptance Criteria Checklist" on MI350X and MI355X pages, adding introductory text that frames the section as a checklist-driven Go-Live readiness tracker (aligned with the updated Word-based customer acceptance guide)
- Splits the System Validation section into **Single-Node Tests** and **Multi-Node Tests** sub-tables, each with run-time requirements
- Adds previously missing tests to GPU summary pages: `gfx_lvl4`, single-node RCCL, OFED performance tests, multi-node RCCL, and AI workload validation
- Updates `hbm_lvl5` from 2 iterations to 4 iterations (8 hours) and promotes `miniHPL` from optional to required (3 hours)

## Test plan

- [ ]  Verify Sphinx build passes (`readthedocs` CI)
- [ ]  Confirm all cross-reference links resolve correctly on the rendered site
- [ ]  Review run-time values against final Word document revision