### PR TITLE
Add markdown button and make llms.txt available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,8 @@ external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
 
+import re
+
 EXCLUDED_DIRS = {
     "_build",
     "_templates",
@@ -50,8 +52,58 @@ EXCLUDED_DIRS = {
     ".venv",
 }
 
+MARKUP_PREFIXES = (
+    ":::",
+    "```{",
+    "```",
+    ":img-top:",
+    ":class",
+    ":link:",
+    ":link-type:",
+    ":shadow:",
+    ":columns:",
+    ":padding:",
+    ":gutter:",
+    ":open:",
+    ":name:",
+    ":header-rows:",
+    ":alt:",
+    "+++",
+    "<",
+    "-->",
+    "{bdg-",
+)
+
+# Matches lines like "align: center", "alt:", "name: foo" (directive options
+# not starting with a colon, common in MyST figure/table fences)
+_BARE_DIRECTIVE_RE = re.compile(r"^[a-z][a-z_-]*:\s*\S*$")
+
+# Matches MyST/RST anchor labels like "(gpu-arch-documentation)="
+_ANCHOR_LABEL_RE = re.compile(r"^\(\w[\w-]*\)=$")
+
+MIN_PROSE_LINES = 10
+
+
 def should_skip(path: Path) -> bool:
     return any(part in EXCLUDED_DIRS for part in path.parts)
+
+
+def is_prose_line(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if stripped.startswith(MARKUP_PREFIXES):
+        return False
+    # Drop bare directive-option lines (e.g. "align: center", "alt:")
+    if _BARE_DIRECTIVE_RE.match(stripped):
+        return False
+    # Drop MyST/RST anchor labels (e.g. "(gpu-arch-documentation)=")
+    if _ANCHOR_LABEL_RE.match(stripped):
+        return False
+    # Drop lines that contain an HTML tag anywhere (e.g. ".</p>")
+    if re.search(r"</?[a-zA-Z]", stripped):
+        return False
+    return True
 
 
 def generate_combined_markdown(app, exception):
@@ -60,33 +112,47 @@ def generate_combined_markdown(app, exception):
 
     docs_root = Path(app.srcdir)
     output_file = Path(app.outdir) / "llms.txt"
-
-    print(output_file)
-
-    all_files = sorted(docs_root.rglob("*.md"))
+    base_file = docs_root / "llms.txt"
 
     combined = []
-    combined.append("# Combined Documentation\n")
+
+    if base_file.exists():
+        base_text = base_file.read_text(encoding="utf-8").rstrip().rstrip("-").rstrip()
+        combined.append(base_text)
+    else:
+        combined.append("# AMD Instinct Customer Acceptance Guide")
+
+    all_files = sorted(docs_root.rglob("*.md"))
 
     for doc_file in all_files:
         if should_skip(doc_file):
             continue
 
-        relative = doc_file.relative_to(docs_root)
-
-        combined.append(f"\n---\n")
-        combined.append(f"\n# {relative}\n")
+        if doc_file == base_file:
+            continue
 
         try:
             content = doc_file.read_text(encoding="utf-8")
-            combined.append(content)
-            combined.append("\n")
+        except Exception:
+            continue
 
-        except Exception as e:
-            combined.append(f"\n[ERROR reading file: {e}]\n")
+        lines = content.splitlines()
+        prose_lines = [line for line in lines if is_prose_line(line)]
+
+        if len(prose_lines) < MIN_PROSE_LINES:
+            continue
+
+        relative = doc_file.relative_to(docs_root)
+        cleaned = "\n".join(
+            line for line in lines
+            if line.strip() == "" or is_prose_line(line)
+        )
+
+        combined.append(f"\n\n---\n\n# {relative}\n")
+        combined.append(cleaned.strip())
 
     output_file.write_text(
-        "\n".join(combined),
+        "\n".join(combined) + "\n",
         encoding="utf-8",
     )
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,10 @@ EXCLUDED_DIRS = {
     ".venv",
 }
 
+EXCLUDED_FILES = {
+    "notices.md",
+}
+
 MARKUP_PREFIXES = (
     ":::",
     "```{",
@@ -85,7 +89,10 @@ MIN_PROSE_LINES = 10
 
 
 def should_skip(path: Path) -> bool:
-    return any(part in EXCLUDED_DIRS for part in path.parts)
+    return (
+        any(part in EXCLUDED_DIRS for part in path.parts)
+        or path.name in EXCLUDED_FILES
+    )
 
 
 def is_prose_line(line: str) -> bool:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,6 +90,9 @@ _ANCHOR_LABEL_RE = re.compile(r"^\(\w[\w-]*\)=$")
 # Matches RST section underlines (e.g. "====", "----", "~~~~")
 _RST_UNDERLINE_RE = re.compile(r"^[=\-~^\"\'#*+]{3,}$")
 
+# Matches RST code block directives (e.g. ".. code-block:: cpp", ".. code:: sh")
+_RST_CODE_BLOCK_RE = re.compile(r"^\.\.\s+(code-block|code|sourcecode)::")
+
 MIN_PROSE_LINES = 10
 
 
@@ -112,14 +115,13 @@ def is_prose_line(line: str) -> bool:
     # Drop MyST/RST anchor labels (e.g. "(gpu-arch-documentation)=")
     if _ANCHOR_LABEL_RE.match(stripped):
         return False
-    # Drop lines that contain an HTML tag anywhere (e.g. ".</p>")
-    if re.search(r"</?[a-zA-Z]", stripped):
-        return False
     # Drop RST directives, comments, hyperlink targets, and substitution definitions
     if stripped.startswith(".."):
         return False
-    # Drop RST field list items (e.g. ":type: int") and MyST directive options not in MARKUP_PREFIXES
-    if re.match(r"^:[A-Za-z]", stripped):
+    # Drop RST field list items (e.g. ":type: int") and MyST directive options without
+    # a leading colon (e.g. "align: center"). Excludes inline roles at line start
+    # (e.g. ":cpp:func:`hipMalloc` returns..." or ":ref:`foo <bar>` describes...").
+    if re.match(r"^:[A-Za-z][A-Za-z0-9_-]*:(\s|$)", stripped):
         return False
     # Drop RST section underlines (e.g. "====", "----", "~~~~")
     if _RST_UNDERLINE_RE.match(stripped):
@@ -166,10 +168,32 @@ def generate_combined_markdown(app, exception):
             continue
 
         relative = doc_file.relative_to(docs_root)
-        cleaned = "\n".join(
-            line for line in lines
-            if line.strip() == "" or is_prose_line(line)
-        )
+        in_backtick_fence = False
+        in_rst_code_block = False
+        kept = []
+        for line in lines:
+            stripped = line.strip()
+            # Backtick fences (MyST/Markdown)
+            if stripped.startswith("```"):
+                in_backtick_fence = not in_backtick_fence
+                kept.append(line)
+                continue
+            if in_backtick_fence:
+                kept.append(line)
+                continue
+            # RST code block: exit when a non-blank, non-indented line appears
+            if in_rst_code_block:
+                if not stripped or line[0] in (" ", "\t"):
+                    kept.append(line)
+                    continue
+                in_rst_code_block = False
+            # RST code block: enter on directive line (directive itself is dropped)
+            if _RST_CODE_BLOCK_RE.match(stripped):
+                in_rst_code_block = True
+                continue
+            if not stripped or is_prose_line(line):
+                kept.append(line)
+        cleaned = "\n".join(kept)
 
         combined.append(f"\n\n---\n\n# {relative}\n")
         combined.append(cleaned.strip())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,6 @@ MARKUP_PREFIXES = (
     ":header-rows:",
     ":alt:",
     "+++",
-    "<",
     "-->",
     "{bdg-",
 )
@@ -92,6 +91,17 @@ _RST_UNDERLINE_RE = re.compile(r"^[=\-~^\"\'#*+]{3,}$")
 
 # Matches RST code block directives (e.g. ".. code-block:: cpp", ".. code:: sh")
 _RST_CODE_BLOCK_RE = re.compile(r"^\.\.\s+(code-block|code|sourcecode)::")
+
+# Matches markdown table separator rows (e.g. "|---|---|", "| :--- | ---: |").
+_MD_TABLE_SEP_RE = re.compile(r"^\|[\s|:\-]+\|$")
+
+# Matches RST directives whose indented body should be discarded (e.g. raw HTML).
+_RST_SKIP_BLOCK_RE = re.compile(r"^\.\.\s+raw::")
+
+# Matches HTML tags (e.g. "<div>", "</p>", "<!--") but NOT RST hyperlink URL
+# continuation lines (e.g. "<https://...>`_").  The negative lookahead excludes
+# URL schemes so that multi-line RST inline hyperlinks are preserved.
+_HTML_TAG_RE = re.compile(r"^<(?!https?://|ftp://|mailto:)[a-zA-Z/!]")
 
 MIN_PROSE_LINES = 10
 
@@ -115,13 +125,24 @@ def is_prose_line(line: str) -> bool:
     # Drop MyST/RST anchor labels (e.g. "(gpu-arch-documentation)=")
     if _ANCHOR_LABEL_RE.match(stripped):
         return False
+    # Drop markdown table separator rows (e.g. "|---|---|", "| :--- | ---: |")
+    if _MD_TABLE_SEP_RE.match(stripped):
+        return False
+    # Drop HTML tags (e.g. "<div>", "</p>") but keep RST hyperlink URL
+    # continuation lines (e.g. "<https://rocm.docs.amd.com/...>`_")
+    if _HTML_TAG_RE.match(stripped):
+        return False
     # Drop RST directives, comments, hyperlink targets, and substitution definitions
     if stripped.startswith(".."):
         return False
-    # Drop RST field list items (e.g. ":type: int") and MyST directive options without
-    # a leading colon (e.g. "align: center"). Excludes inline roles at line start
-    # (e.g. ":cpp:func:`hipMalloc` returns..." or ":ref:`foo <bar>` describes...").
-    if re.match(r"^:[A-Za-z][A-Za-z0-9_-]*:(\s|$)", stripped):
+    # Drop YAML frontmatter key-value pairs (e.g. "description lang=en": "text")
+    if stripped.startswith('"') and re.match(r'^"[^"]+"\s*:', stripped):
+        return False
+    # Drop RST field list items (e.g. ":type: int") and extended RST meta
+    # options (e.g. ":description lang=en: text"). Excludes inline roles at line
+    # start (e.g. ":cpp:func:`hipMalloc` returns..." or ":ref:`foo <bar>` describes...")
+    # because those are followed by a backtick, not a space or end-of-line.
+    if re.match(r"^:[A-Za-z][A-Za-z0-9_ =-]*:(\s|$)", stripped):
         return False
     # Drop RST section underlines (e.g. "====", "----", "~~~~")
     if _RST_UNDERLINE_RE.match(stripped):
@@ -170,6 +191,7 @@ def generate_combined_markdown(app, exception):
         relative = doc_file.relative_to(docs_root)
         in_backtick_fence = False
         in_rst_code_block = False
+        in_rst_skip_block = False
         kept = []
         for line in lines:
             stripped = line.strip()
@@ -181,12 +203,21 @@ def generate_combined_markdown(app, exception):
             if in_backtick_fence:
                 kept.append(line)
                 continue
+            # RST skip block (e.g. .. raw::): discard all indented content
+            if in_rst_skip_block:
+                if not stripped or line[0] in (" ", "\t"):
+                    continue
+                in_rst_skip_block = False
             # RST code block: exit when a non-blank, non-indented line appears
             if in_rst_code_block:
                 if not stripped or line[0] in (" ", "\t"):
                     kept.append(line)
                     continue
                 in_rst_code_block = False
+            # RST raw block: enter and discard both the directive and its body
+            if _RST_SKIP_BLOCK_RE.match(stripped):
+                in_rst_skip_block = True
+                continue
             # RST code block: enter on directive line (directive itself is dropped)
             if _RST_CODE_BLOCK_RE.match(stripped):
                 in_rst_code_block = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,8 @@ external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
 
+html_extra_path = ["llms.txt"]
+
 import re
 
 EXCLUDED_DIRS = {
@@ -130,7 +132,7 @@ def generate_combined_markdown(app, exception):
         return
 
     docs_root = Path(app.srcdir)
-    output_file = Path(app.outdir) / "llms.txt"
+    output_file = Path(app.outdir) / "llms-full.txt"
     base_file = docs_root / "llms.txt"
 
     combined = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,8 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
+import shutil
 
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "instinct.docs.amd.com")
 html_context = {}
@@ -24,6 +26,7 @@ html_theme = "rocm_docs_theme"
 html_theme_options = {
     "flavor": "instinct",
     "link_main_doc": True,
+    "use_download_button": True,
     "nav_secondary_items": {
         "Community": "https://github.com/ROCm/ROCm/discussions",
         "Blogs": "https://rocm.blogs.amd.com/",
@@ -38,3 +41,54 @@ extensions = ["rocm_docs"]
 external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
+
+EXCLUDED_DIRS = {
+    "_build",
+    "_templates",
+    "_static",
+    ".git",
+    ".venv",
+}
+
+def should_skip(path: Path) -> bool:
+    return any(part in EXCLUDED_DIRS for part in path.parts)
+
+
+def generate_combined_markdown(app, exception):
+    if exception:
+        return
+
+    docs_root = Path(app.srcdir)
+    output_file = Path(app.outdir) / "llms.txt"
+
+    print(output_file)
+
+    all_files = sorted(docs_root.rglob("*.md"))
+
+    combined = []
+    combined.append("# Combined Documentation\n")
+
+    for doc_file in all_files:
+        if should_skip(doc_file):
+            continue
+
+        relative = doc_file.relative_to(docs_root)
+
+        combined.append(f"\n---\n")
+        combined.append(f"\n# {relative}\n")
+
+        try:
+            content = doc_file.read_text(encoding="utf-8")
+            combined.append(content)
+            combined.append("\n")
+
+        except Exception as e:
+            combined.append(f"\n[ERROR reading file: {e}]\n")
+
+    output_file.write_text(
+        "\n".join(combined),
+        encoding="utf-8",
+    )
+
+def setup(app):
+    app.connect("build-finished", generate_combined_markdown)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,9 @@ _BARE_DIRECTIVE_RE = re.compile(r"^[a-z][a-z_-]*:\s*\S*$")
 # Matches MyST/RST anchor labels like "(gpu-arch-documentation)="
 _ANCHOR_LABEL_RE = re.compile(r"^\(\w[\w-]*\)=$")
 
+# Matches RST section underlines (e.g. "====", "----", "~~~~")
+_RST_UNDERLINE_RE = re.compile(r"^[=\-~^\"\'#*+]{3,}$")
+
 MIN_PROSE_LINES = 10
 
 
@@ -110,6 +113,15 @@ def is_prose_line(line: str) -> bool:
     # Drop lines that contain an HTML tag anywhere (e.g. ".</p>")
     if re.search(r"</?[a-zA-Z]", stripped):
         return False
+    # Drop RST directives, comments, hyperlink targets, and substitution definitions
+    if stripped.startswith(".."):
+        return False
+    # Drop RST field list items (e.g. ":type: int") and MyST directive options not in MARKUP_PREFIXES
+    if re.match(r"^:[A-Za-z]", stripped):
+        return False
+    # Drop RST section underlines (e.g. "====", "----", "~~~~")
+    if _RST_UNDERLINE_RE.match(stripped):
+        return False
     return True
 
 
@@ -129,7 +141,9 @@ def generate_combined_markdown(app, exception):
     else:
         combined.append("# AMD Instinct Customer Acceptance Guide")
 
-    all_files = sorted(docs_root.rglob("*.md"))
+    all_files = sorted(
+        list(docs_root.rglob("*.md")) + list(docs_root.rglob("*.rst"))
+    )
 
     for doc_file in all_files:
         if should_skip(doc_file):

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,40 @@
+# AMD Instinct Customer Acceptance Guide
+
+> A structured, repeatable methodology for configuring, validating, benchmarking, and baselining AMD Instinct GPU platforms at both single-node and multi-node (cluster) levels. Covers node validation, cluster networking, RDMA benchmarking, and acceptance criteria for HPC and AI workloads.
+
+## GPU platforms
+
+- [AMD Instinct MI355X](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/gpus/mi355x.html): MI355X-specific prerequisites, health checks, validation steps, and performance acceptance criteria.
+- [AMD Instinct MI350X](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/gpus/mi350x.html): MI350X-specific prerequisites, health checks, validation steps, and performance acceptance criteria.
+- [AMD Instinct MI325X](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/gpus/mi325x.html): MI325X-specific requirements, specifications, and acceptance testing criteria.
+- [AMD Instinct MI300X](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/gpus/mi300x.html): MI300X-specific requirements, specifications, and acceptance testing criteria.
+
+## Node validation
+
+- [System prerequisites](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/prerequisites.html): System requirements common to all AMD Instinct GPU models.
+- [Firmware updates](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/firmware-updates.html): Supported methods for updating GPU runtime firmware and system firmware on AMD Instinct platforms.
+- [BIOS settings](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/bios-settings.html): BIOS configuration settings common to all AMD Instinct GPU models.
+- [Kernel parameters](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/kernel-parameters.html): GRUB and kernel parameter settings common to all AMD Instinct GPU models.
+- [OS tuning](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/os-tuning.html): C-states, NUMA configuration, and environment variables for AMD Instinct GPU systems.
+- [System setup](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/system-setup.html): Preparing, installing, and validating the ROCm software stack on AMD Instinct GPU systems.
+- [Health checks](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/health-checks.html): Basic system health checks to verify components are operating at peak performance before extensive validation.
+- [System validation](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/system-validation.html): RVS, AGFHC, and additional tools for validating AMD Instinct GPU systems.
+- [Workload validation](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/workload-validation.html): Validate AI model performance, including LLMs, on AMD Instinct systems.
+- [RCCL benchmarking](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/common/rccl-benchmarking.html): Benchmark and validate RCCL collective communication performance for single-node and multi-node configurations.
+
+## Cluster and network validation
+
+- [NIC driver installation](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/network/nic-installation.html): Vendor-specific guidance for installing and configuring NIC drivers and supporting software.
+- [Network configuration](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/network/configuration.html): Configure network routing to ensure each backend interface is used exclusively for GPU-driven cluster communications.
+- [Topology mapping](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/network/topology-mapping.html): Map GPUs and NICs by NUMA node and PCIe root complex to minimize latency for RDMA and AI/HPC workloads.
+- [Network optimization](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/network/optimization.html): NIC performance optimization for cluster networking.
+- [RDMA benchmarking](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/network/rdma-benchmarking.html): Validate RDMA performance and reliability, including link speed verification, RDMA benchmarks, and RCCL collective operations.
+- [Cluster validation](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/network/validation.html): Multi-node network and cluster validation for data throughput and cluster efficiency.
+
+## Reference
+
+- [Related documentation](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/reference/related-documentation.html): Reference documents and links for system setup and test execution.
+- [Glossary](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/reference/glossary.html): Terms and definitions used throughout this guide.
+- [ROCm technical support](https://instinct.docs.amd.com/projects/system-acceptance/en/latest/reference/rocm-techsupport.html): Collect logs using the rocm_techsupport.sh utility for troubleshooting.
+
+---


### PR DESCRIPTION
## Motivation

AI coding assistants and agents increasingly need documentation in machine-readable formats. Two patterns are emerging as standards: per-page Markdown download (so users and agents can copy page content directly into an AI context window) and llms.txt (a combined documentation file that AI agents can discover and ingest). This PR adds both capabilities to make the documentation more accessible to AI-assisted workflows.

## Technical Details

Three changes to docs/conf.py, plus a new docs/llms.txt:

### Enable the theme download button

Sets "use_download_button": True in html_theme_options, which activates the built-in per-page download action provided by the Sphinx book theme. This allows readers to download the current page as Markdown or RST depending on the source format.

### Add a curated llms.txt index

Adds a base docs/llms.txt that serves as a curated index of all documentation pages, including those sourced from RST. Sets html_extra_path = ["llms.txt"] so Sphinx copies it to the output root, making it discoverable at /llms.txt.

### Add llms-full.txt generation

Adds a Sphinx build-finished hook (generate_combined_markdown) that filters and combines Markdown and RST source files into llms-full.txt. Each file is filtered through a prose detection pass that strips code fences, directive options, MyST/RST anchors, and inline HTML. Files with fewer than 10 prose lines are skipped entirely to avoid including navigation-only or boilerplate pages. Files in build, static, template, and VCS directories are excluded.

This follows the https://llmstxt.org/ for AI agent documentation discovery, and is compatible with https://docs.readthedocs.com/platform/stable/reference/llms-txt.html.

## Test Plan

- Verify the download button appears on documentation pages
- Verify llms.txt is available at {project_url}/llms.txt and contains only the curated index
- Verify llms-full.txt is available at {project_url}/llms-full.txt
- Confirm the curated index section appears at the top of llms-full.txt
- Confirm excluded directories (.git, _build, _static, _templates, .venv) are not represented in llms-full.txt
- Confirm navigation-only pages do not appear in the stitched output

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.